### PR TITLE
Install protoc in the node-liveness-checker build image

### DIFF
--- a/node-liveness-checker/scripts/Dockerfile
+++ b/node-liveness-checker/scripts/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update && apt-get install -y libssl-dev pkg-config cmake g++ && rm -
 # Install protobuf
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-x86_64.zip \
     && unzip protoc-3.15.3-linux-x86_64.zip \
-    && sudo mv ./bin/protoc /usr/bin/protoc
+    && mv ./bin/protoc /usr/bin/protoc

--- a/node-liveness-checker/scripts/Dockerfile
+++ b/node-liveness-checker/scripts/Dockerfile
@@ -9,5 +9,5 @@ RUN apt-get update && apt-get install -y libssl-dev pkg-config cmake g++ && rm -
 # Install protobuf
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-x86_64.zip \
     && unzip protoc-3.15.3-linux-x86_64.zip \
-    && mv ./bin/protoc \
+    && mv ./bin/protoc /usr/bin/protoc \
     && chmod +x /usr/bin/protoc

--- a/node-liveness-checker/scripts/Dockerfile
+++ b/node-liveness-checker/scripts/Dockerfile
@@ -9,4 +9,5 @@ RUN apt-get update && apt-get install -y libssl-dev pkg-config cmake g++ && rm -
 # Install protobuf
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-x86_64.zip \
     && unzip protoc-3.15.3-linux-x86_64.zip \
-    && mv ./bin/protoc /usr/bin/protoc
+    && mv ./bin/protoc \
+    && chmod +x /usr/bin/protoc

--- a/node-liveness-checker/scripts/Dockerfile
+++ b/node-liveness-checker/scripts/Dockerfile
@@ -5,3 +5,8 @@ RUN rustup component add rustfmt
 
 # Install system dependencies ('cmake' and 'g++' are dependencies of Rust crate 'prost-build').
 RUN apt-get update && apt-get install -y libssl-dev pkg-config cmake g++ && rm -rf /var/lib/apt/lists/*
+
+# Install protobuf
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-x86_64.zip \
+    && unzip protoc-3.15.3-linux-x86_64.zip \
+    && sudo mv ./bin/protoc /usr/bin/protoc


### PR DESCRIPTION
## Purpose

The Jenkins build needs to have protoc installed to build the node-liveness-checker.

## Changes

Added protoc installation to the node-liveness-checker builder image.

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
