### PR TITLE
Add tables recording affected contracts/accounts for each transactions

### DIFF
--- a/kpi-tracker/Cargo.lock
+++ b/kpi-tracker/Cargo.lock
@@ -43,6 +43,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,7 +440,9 @@ dependencies = [
  "chrono",
  "clap",
  "concordium-rust-sdk",
+ "env_logger",
  "futures",
+ "log",
  "tokio",
  "tonic",
 ]
@@ -846,6 +857,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1176,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1962,6 +1992,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/kpi-tracker/Cargo.toml
+++ b/kpi-tracker/Cargo.toml
@@ -10,6 +10,8 @@ anyhow = "1.0"
 chrono = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 concordium-rust-sdk = { version = "*", path = "../deps/concordium-rust-sdk" }
+env_logger = "0.10"
 futures = "0.3"
+log = "0.4"
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 tonic = "0.8"

--- a/kpi-tracker/src/main.rs
+++ b/kpi-tracker/src/main.rs
@@ -27,14 +27,14 @@ struct Args {
         help = "The endpoint is expected to point to a concordium node grpc v2 API.",
         default_value = "http://localhost:20001"
     )]
-    node: Endpoint,
+    node:       Endpoint,
     /// How many blocks to process.
     // Only here for testing purposes...
     #[arg(long = "num-blocks", default_value_t = 10000)]
     num_blocks: u64,
     /// Logging level of the application
     #[arg(long = "log-level", default_value = "debug")]
-    log_level: log::LevelFilter,
+    log_level:  log::LevelFilter,
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, PartialOrd, Ord, Debug, Hash)]
@@ -50,9 +50,7 @@ impl From<AccountAddress> for CanonicalAccountAddress {
     }
 }
 impl fmt::Display for CanonicalAccountAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        AccountAddress(self.0).fmt(f)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { AccountAddress(self.0).fmt(f) }
 }
 
 /// Information about individual blocks. Useful for linking entities to a block
@@ -65,7 +63,7 @@ struct BlockDetails {
     block_time: DateTime<Utc>,
     /// Height of block from genesis. Used to restart the process of collecting
     /// metrics from the latest block recorded.
-    height: AbsoluteBlockHeight,
+    height:     AbsoluteBlockHeight,
 }
 
 /// Holds selected attributes about accounts created on chain.
@@ -84,11 +82,11 @@ struct TransactionDetails {
     /// transaction was rejected due to serialization failure.
     transaction_type: Option<TransactionType>,
     /// Foreign key to the block in which the transaction was finalized.
-    block_hash: BlockHash,
+    block_hash:       BlockHash,
     /// The cost of the transaction.
-    cost: Amount,
+    cost:             Amount,
     /// Whether the transaction failed or not.
-    is_success: bool,
+    is_success:       bool,
 }
 
 /// Holds selected attributes of a contract module deployed on chain.
@@ -110,14 +108,14 @@ struct ContractInstanceDetails {
 /// Represents a relation between an account and a transaction
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
 struct TransactionAccountRelation {
-    account: CanonicalAccountAddress,
+    account:     CanonicalAccountAddress,
     transaction: TransactionHash,
 }
 
 /// Represents a relation between a contract and a transaction
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
 struct TransactionContractRelation {
-    contract: ContractAddress,
+    contract:    ContractAddress,
     transaction: TransactionHash,
 }
 
@@ -264,7 +262,7 @@ fn to_block_events(block_hash: BlockHash, block_item: BlockItemSummary) -> Vec<B
                 .affected_addresses()
                 .into_iter()
                 .map(|address| TransactionAccountRelation {
-                    account: CanonicalAccountAddress::from(address),
+                    account:     CanonicalAccountAddress::from(address),
                     transaction: block_item.hash,
                 })
                 .collect();
@@ -400,7 +398,7 @@ async fn process_genesis_block(
 
     let block_details = BlockDetails {
         block_time: block_info.block_slot_time,
-        height: block_info.block_height,
+        height:     block_info.block_height,
     };
 
     let genesis_accounts = accounts_in_block(node, block_hash).await?;
@@ -424,7 +422,7 @@ async fn process_block(
 
     let block_details = BlockDetails {
         block_time: block_info.block_slot_time,
-        height: block_info.block_height,
+        height:     block_info.block_height,
     };
 
     let mut accounts: BTreeMap<CanonicalAccountAddress, AccountDetails> = BTreeMap::new();

--- a/kpi-tracker/src/main.rs
+++ b/kpi-tracker/src/main.rs
@@ -27,14 +27,14 @@ struct Args {
         help = "The endpoint is expected to point to a concordium node grpc v2 API.",
         default_value = "http://localhost:20001"
     )]
-    node:       Endpoint,
+    node: Endpoint,
     /// How many blocks to process.
     // Only here for testing purposes...
     #[arg(long = "num-blocks", default_value_t = 10000)]
     num_blocks: u64,
     /// Logging level of the application
     #[arg(long = "log-level", default_value = "debug")]
-    log_level:  log::LevelFilter,
+    log_level: log::LevelFilter,
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, PartialOrd, Ord, Debug, Hash)]
@@ -50,7 +50,9 @@ impl From<AccountAddress> for CanonicalAccountAddress {
     }
 }
 impl fmt::Display for CanonicalAccountAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { AccountAddress(self.0).fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        AccountAddress(self.0).fmt(f)
+    }
 }
 
 /// Information about individual blocks. Useful for linking entities to a block
@@ -63,7 +65,7 @@ struct BlockDetails {
     block_time: DateTime<Utc>,
     /// Height of block from genesis. Used to restart the process of collecting
     /// metrics from the latest block recorded.
-    height:     AbsoluteBlockHeight,
+    height: AbsoluteBlockHeight,
 }
 
 /// Holds selected attributes about accounts created on chain.
@@ -82,11 +84,11 @@ struct TransactionDetails {
     /// transaction was rejected due to serialization failure.
     transaction_type: Option<TransactionType>,
     /// Foreign key to the block in which the transaction was finalized.
-    block_hash:       BlockHash,
+    block_hash: BlockHash,
     /// The cost of the transaction.
-    cost:             Amount,
+    cost: Amount,
     /// Whether the transaction failed or not.
-    is_success:       bool,
+    is_success: bool,
 }
 
 /// Holds selected attributes of a contract module deployed on chain.
@@ -107,11 +109,17 @@ struct ContractInstanceDetails {
 
 /// Represents a relation between an account and a transaction
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
-struct TransactionAccountRelation(CanonicalAccountAddress, TransactionHash);
+struct TransactionAccountRelation {
+    account: CanonicalAccountAddress,
+    transaction: TransactionHash,
+}
 
 /// Represents a relation between a contract and a transaction
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
-struct TransactionContractRelation(ContractAddress, TransactionHash);
+struct TransactionContractRelation {
+    contract: ContractAddress,
+    transaction: TransactionHash,
+}
 
 type BlocksTable = HashMap<BlockHash, BlockDetails>;
 type AccountsTable = HashMap<CanonicalAccountAddress, AccountDetails>;
@@ -255,35 +263,20 @@ fn to_block_events(block_hash: BlockHash, block_item: BlockItemSummary) -> Vec<B
             let affected_accounts: Vec<TransactionAccountRelation> = block_item
                 .affected_addresses()
                 .into_iter()
-                .map(|address| {
-                    TransactionAccountRelation(
-                        CanonicalAccountAddress::from(address),
-                        block_item.hash,
-                    )
+                .map(|address| TransactionAccountRelation {
+                    account: CanonicalAccountAddress::from(address),
+                    transaction: block_item.hash,
                 })
                 .collect();
 
             let affected_contracts: Vec<TransactionContractRelation> = block_item
                 .affected_contracts()
                 .into_iter()
-                .map(|address| TransactionContractRelation(address, block_item.hash))
+                .map(|contract| TransactionContractRelation {
+                    contract,
+                    transaction: block_item.hash,
+                })
                 .collect();
-
-            log::debug!(
-                "Account transaction found: {}\n{:?}\n{}\n{}",
-                block_item.hash,
-                details,
-                &affected_accounts
-                    .iter()
-                    .map(|account_relation| format!("{:?}", account_relation))
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-                &affected_contracts
-                    .iter()
-                    .map(|contract_relation| format!("{:?}", contract_relation))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            );
 
             let event = BlockEvent::AccountTransaction(
                 block_item.hash,
@@ -297,13 +290,8 @@ fn to_block_events(block_hash: BlockHash, block_item: BlockItemSummary) -> Vec<B
             match &atd.effects {
                 AccountTransactionEffects::ModuleDeployed { module_ref } => {
                     let details = ContractModuleDetails { block_hash };
-                    log::debug!(
-                        "Contract module deployment found: {}\n{:?}",
-                        module_ref,
-                        &details
-                    );
-
                     let event = BlockEvent::ContractModuleDeployment(*module_ref, details);
+
                     events.push(event);
                 }
                 AccountTransactionEffects::ContractInitialized { data } => {
@@ -311,13 +299,8 @@ fn to_block_events(block_hash: BlockHash, block_item: BlockItemSummary) -> Vec<B
                         block_hash,
                         module_ref: data.origin_ref,
                     };
-                    log::debug!(
-                        "Contract instantiation found: {}\n{:?}",
-                        data.address,
-                        &details
-                    );
-
                     let event = BlockEvent::ContractInstantiation(data.address, details);
+
                     events.push(event);
                 }
                 _ => {}
@@ -325,9 +308,8 @@ fn to_block_events(block_hash: BlockHash, block_item: BlockItemSummary) -> Vec<B
         }
         AccountCreation(acd) => {
             let details = account_details(block_hash, acd);
-            log::debug!("Account creation found: {}\n{:?}", acd.address, &details);
-
             let block_event = BlockEvent::AccountCreation(acd.address, details);
+
             events.push(block_event);
         }
         _ => {}
@@ -418,25 +400,10 @@ async fn process_genesis_block(
 
     let block_details = BlockDetails {
         block_time: block_info.block_slot_time,
-        height:     block_info.block_height,
+        height: block_info.block_height,
     };
 
     let genesis_accounts = accounts_in_block(node, block_hash).await?;
-
-    log::debug!(
-        "Genesis block processed: {}\n{:?}",
-        block_hash,
-        block_details
-    );
-    log::debug!(
-        "Genesis accounts found:\n{}",
-        &genesis_accounts
-            .keys()
-            .map(|address| address.to_string())
-            .collect::<Vec<_>>()
-            .join("\n")
-    );
-
     init_db(db, (block_hash, block_details), genesis_accounts);
 
     Ok(())
@@ -457,7 +424,7 @@ async fn process_block(
 
     let block_details = BlockDetails {
         block_time: block_info.block_slot_time,
-        height:     block_info.block_height,
+        height: block_info.block_height,
     };
 
     let mut accounts: BTreeMap<CanonicalAccountAddress, AccountDetails> = BTreeMap::new();
@@ -482,11 +449,8 @@ async fn process_block(
                     affected_contracts,
                 ) => {
                     account_transactions.insert(hash, details);
-
                     transaction_account_relations.extend(affected_accounts.into_iter());
-                    if !affected_contracts.is_empty() {
-                        transaction_contract_relations.extend(affected_contracts.into_iter());
-                    }
+                    transaction_contract_relations.extend(affected_contracts.into_iter());
                 }
                 BlockEvent::ContractModuleDeployment(module_ref, details) => {
                     contract_modules.insert(module_ref, details);
@@ -617,10 +581,10 @@ fn print_db(db: DB) {
     let tar_strings: Vec<String> = db
         .transaction_account_relations
         .into_iter()
-        .map(|TransactionAccountRelation(account, transaction)| {
+        .map(|tar| {
             format!(
                 "Transaction-Account relation: {} - {}",
-                transaction, account
+                tar.transaction, tar.account
             )
         })
         .collect();
@@ -635,10 +599,10 @@ fn print_db(db: DB) {
     let tcr_strings: Vec<String> = db
         .transaction_contract_relations
         .into_iter()
-        .map(|TransactionContractRelation(contract, transaction)| {
+        .map(|tcr| {
             format!(
                 "Transaction-Contract relation: {} - {}",
-                transaction, contract
+                tcr.transaction, tcr.contract
             )
         })
         .collect();
@@ -676,12 +640,14 @@ async fn use_node(db: &mut DB, from_height: AbsoluteBlockHeight) -> anyhow::Resu
     if from_height.height == 0 {
         if let Some(genesis_block) = blocks_stream.next().await {
             process_genesis_block(&mut node, genesis_block.block_hash, db).await?;
+            log::info!("Processed genesis block: {}", genesis_block.block_hash);
         }
     }
 
-    for _ in from_height.height + 1..blocks_to_process {
+    for height in from_height.height + 1..blocks_to_process {
         if let Some(block) = blocks_stream.next().await {
             process_block(&mut node, block.block_hash, db).await?;
+            log::info!("Processed block ({}): {}", height, block.block_hash);
         }
     }
 

--- a/kpi-tracker/src/main.rs
+++ b/kpi-tracker/src/main.rs
@@ -542,7 +542,8 @@ fn print_db(db: DB) {
         .collect();
 
     println!(
-        "Transaction-Account relations stored:\n{}\n",
+        "{} transaction-account relations stored:\n{}\n",
+        tar_strings.len(),
         tar_strings.join("\n")
     );
 
@@ -559,7 +560,8 @@ fn print_db(db: DB) {
         .collect();
 
     println!(
-        "Transaction-Contract relations stored:\n{}\n",
+        "{} transaction-contract relations stored:\n{}\n",
+        tcr_strings.len(),
         tcr_strings.join("\n")
     );
 }

--- a/kpi-tracker/src/main.rs
+++ b/kpi-tracker/src/main.rs
@@ -113,7 +113,7 @@ struct ContractInstanceDetails {
 /// Represents a compound unique constraint for relations between accounts and
 /// transactions
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
-struct TransactionAccountRelation(AccountAddress, TransactionHash);
+struct TransactionAccountRelation(CanonicalAccountAddress, TransactionHash);
 
 /// Represents a compound unique constraint for relations between contracts and
 /// transactions
@@ -261,10 +261,9 @@ fn to_block_events(block_hash: BlockHash, block_item: BlockItemSummary) -> Vec<B
             log::debug!("TRANSACTION: {}", block_item.hash);
 
             let details = get_account_transaction_details(atd, block_hash);
-            let affected_accounts = block_item
-                .affected_addresses()
-                .into_iter()
-                .map(|address| TransactionAccountRelation(address, block_item.hash));
+            let affected_accounts = block_item.affected_addresses().into_iter().map(|address| {
+                TransactionAccountRelation(CanonicalAccountAddress::from(address), block_item.hash)
+            });
 
             let affected_contracts = block_item
                 .affected_contracts()

--- a/kpi-tracker/src/main.rs
+++ b/kpi-tracker/src/main.rs
@@ -4,10 +4,9 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
 use clap::Parser;
-use concordium_rust_sdk::smart_contracts::common::ACCOUNT_ADDRESS_SIZE;
 use concordium_rust_sdk::{
     id::types::AccountCredentialWithoutProofs,
-    smart_contracts::common::{AccountAddress, Amount},
+    smart_contracts::common::{AccountAddress, Amount, ACCOUNT_ADDRESS_SIZE},
     types::{
         hashes::{BlockHash, TransactionHash},
         smart_contracts::ModuleRef,
@@ -28,7 +27,7 @@ struct Args {
         help = "The endpoint is expected to point to a concordium node grpc v2 API.",
         default_value = "http://localhost:20001"
     )]
-    node: Endpoint,
+    node:       Endpoint,
     /// How many blocks to process.
     // Only here for testing purposes...
     #[arg(long = "num-blocks", default_value_t = 10000)]
@@ -53,13 +52,11 @@ impl From<AccountAddress> for CanonicalAccountAddress {
     }
 }
 impl fmt::Display for CanonicalAccountAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        AccountAddress(self.0).fmt(f)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { AccountAddress(self.0).fmt(f) }
 }
 
-/// Information about individual blocks. Useful for linking entities to a block and it's
-/// corresponding attributes.
+/// Information about individual blocks. Useful for linking entities to a block
+/// and it's corresponding attributes.
 #[derive(Debug, Clone, Copy)]
 struct BlockDetails {
     /// Finalization time of the block. Used to show how metrics evolve over
@@ -68,7 +65,7 @@ struct BlockDetails {
     block_time: DateTime<Utc>,
     /// Height of block from genesis. Used to restart the process of collecting
     /// metrics from the latest block recorded.
-    height: AbsoluteBlockHeight,
+    height:     AbsoluteBlockHeight,
 }
 
 /// Holds selected attributes about accounts created on chain.
@@ -87,11 +84,11 @@ struct TransactionDetails {
     /// transaction was rejected due to serialization failure.
     transaction_type: Option<TransactionType>,
     /// Foreign key to the block in which the transaction was finalized.
-    block_hash: BlockHash,
+    block_hash:       BlockHash,
     /// The cost of the transaction.
-    cost: Amount,
+    cost:             Amount,
     /// Whether the transaction failed or not.
-    is_failed: bool,
+    is_failed:        bool,
 }
 
 /// Holds selected attributes of a contract module deployed on chain.
@@ -110,11 +107,13 @@ struct ContractInstanceDetails {
     block_hash: BlockHash,
 }
 
-/// Represents a compound unique constraint for relations between accounts and transactions
+/// Represents a compound unique constraint for relations between accounts and
+/// transactions
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
 struct TransactionAccountRelation(AccountAddress, TransactionHash);
 
-/// Represents a compound unique constraint for relations between contracts and transactions
+/// Represents a compound unique constraint for relations between contracts and
+/// transactions
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
 struct TransactionContractRelation(ContractAddress, TransactionHash);
 
@@ -403,7 +402,7 @@ async fn process_genesis_block(
 
     let block_details = BlockDetails {
         block_time: block_info.block_slot_time,
-        height: block_info.block_height,
+        height:     block_info.block_height,
     };
 
     let genesis_accounts = accounts_in_block(node, block_hash).await?;
@@ -427,7 +426,7 @@ async fn process_block(
 
     let block_details = BlockDetails {
         block_time: block_info.block_slot_time,
-        height: block_info.block_height,
+        height:     block_info.block_height,
     };
 
     let mut accounts: BTreeMap<CanonicalAccountAddress, AccountDetails> = BTreeMap::new();


### PR DESCRIPTION
## Purpose

The purpose here is to mimic the database implementation of this, which will be two tables:

- Relations between accounts and transactions (unique "address/transaction hash" pairs)
- Relations between contracts and transactions (unique "contract address/transaction hash" pairs)

Should be reviewed subsequently to #24.

## Changes

- Canonicalize accounts to avoid account aliases
- Add `HashSet`s to store transaction relations 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
