### PR TITLE
Record total stake for payday blocks (which also implies blocks must be > protocol version 4)

### DIFF
--- a/kpi-tracker/src/main.rs
+++ b/kpi-tracker/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     #[arg(long = "num-blocks", default_value_t = 10000)]
     num_blocks:  u64,
     /// Logging level of the application
-    #[arg(long = "log-level", default_value = "debug")]
+    #[arg(long = "log-level", default_value_t = log::LevelFilter::Debug)]
     log_level:   log::LevelFilter,
     /// Block height to start collecting from
     #[arg(long = "from-height", default_value_t = 0)]
@@ -67,7 +67,9 @@ struct BlockDetails {
     /// Height of block from genesis. Used to restart the process of collecting
     /// metrics from the latest block recorded.
     height:      AbsoluteBlockHeight,
-    /// Total amount staked across all pools inclusive passive delegation.
+    /// Total amount staked across all pools inclusive passive delegation. This
+    /// is only recorded for "payday" blocks reflected by `Some`, where non
+    /// payday blocks are reflected by `None`.
     total_stake: Option<Amount>,
 }
 


### PR DESCRIPTION
## Purpose

Records total amount staked across all pools for payday blocks. Right now this is stored as an `Option`, where non-payday blocks will have `None`. I don't know if this is a good solution or not, but for now it's the simplest way to implement this behaviour.

Dependent on #25 

## Changes

- Record total stake for payday blocks
- Add option to specify which block (height) to start from as a command line argument

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
