### PR TITLE
Kpi/activeness performance

### DIFF
--- a/kpi-tracker/resources/populate-activeness.sql
+++ b/kpi-tracker/resources/populate-activeness.sql
@@ -1,0 +1,15 @@
+-- Populates account_activeness "view" with data
+INSERT INTO account_activeness (account, time)
+  SELECT DISTINCT at.account, date_seconds(b.timestamp) as time
+  FROM blocks AS b
+  JOIN transactions AS t ON b.id=t.block
+  JOIN accounts_transactions AS at ON t.id=at.transaction
+  ORDER BY date_seconds(b.timestamp);
+
+-- Populates contract_activeness "view" with data
+INSERT INTO contract_activeness (contract, time)
+  SELECT DISTINCT ct.contract, date_seconds(b.timestamp) as time
+  FROM blocks AS b
+  JOIN transactions AS t ON b.id=t.block
+  JOIN contracts_transactions AS ct ON t.id=ct.transaction
+  ORDER BY date_seconds(b.timestamp);

--- a/kpi-tracker/resources/populate-activeness.sql
+++ b/kpi-tracker/resources/populate-activeness.sql
@@ -4,7 +4,7 @@ INSERT INTO account_activeness (account, time)
   FROM blocks AS b
   JOIN transactions AS t ON b.id=t.block
   JOIN accounts_transactions AS at ON t.id=at.transaction
-  ORDER BY date_seconds(b.timestamp);
+  ORDER BY date_seconds(b.timestamp) ASC;
 
 -- Populates contract_activeness "view" with data
 INSERT INTO contract_activeness (contract, time)
@@ -12,4 +12,4 @@ INSERT INTO contract_activeness (contract, time)
   FROM blocks AS b
   JOIN transactions AS t ON b.id=t.block
   JOIN contracts_transactions AS ct ON t.id=ct.transaction
-  ORDER BY date_seconds(b.timestamp);
+  ORDER BY date_seconds(b.timestamp) ASC;

--- a/kpi-tracker/resources/schema.sql
+++ b/kpi-tracker/resources/schema.sql
@@ -1,4 +1,4 @@
--- Floors a (bigint) timestamp in seconds into date in seconds, e.g. 15/02/2022:14:00:00 -> 15/02/2022:00:00:00
+-- Floors a (bigint) timestamp in seconds into 24h slots in seconds, e.g. 15/02/2022:14:00:00 -> 15/02/2022:00:00:00. This grouping matches how Grafana groups seconds into days.
 CREATE OR REPLACE FUNCTION date_seconds(t bigint)
   RETURNS bigint
   LANGUAGE plpgsql

--- a/kpi-tracker/resources/schema.sql
+++ b/kpi-tracker/resources/schema.sql
@@ -46,16 +46,38 @@ CREATE TABLE IF NOT EXISTS transactions (
 -- Create index on transaction type to improve performance when querying for transactions of specific types.
 CREATE INDEX IF NOT EXISTS transactions_type ON transactions USING HASH (type);
 -- Create index on transactions reference to block to improve performance when querying for transactions linked to specific blocks.
-CREATE INDEX IF NOT EXISTS transactions_block ON transactions USING HASH (block);
+CREATE INDEX IF NOT EXISTS transactions_block ON transactions (block);
 
 -- Keeps track of relations between accounts and transactions to support account activeness.
 CREATE TABLE IF NOT EXISTS accounts_transactions (
   account INT8 NOT NULL REFERENCES accounts(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
   transaction INT8 NOT NULL REFERENCES transactions(id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );
+-- Create index on account-transaction relations references to transactions to improve performance when querying accounts related to specific transactions.
+CREATE INDEX IF NOT EXISTS at_transaction ON accounts_transactions (transaction);
 
 -- Keeps track of relations between contracts and transactions to support contract activeness.
 CREATE TABLE IF NOT EXISTS contracts_transactions (
   contract INT8 NOT NULL REFERENCES contracts(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
   transaction INT8 NOT NULL REFERENCES transactions(id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );
+-- Create index on contract-transaction relations references to transactions to improve performance when querying contracts related to specific transactions.
+CREATE INDEX IF NOT EXISTS ct_transaction ON contracts_transactions (transaction);
+
+-- Create table keeping track of accounts and the dates they have been part of a transations.
+CREATE TABLE IF NOT EXISTS account_activeness (
+  account INT8 NOT NULL REFERENCES accounts(id) ON DELETE RESTRICT ON UPDATE RESTRICT, -- dependant on inserts into `accounts_transactions`.
+  time INT8 NOT NULL, -- Date represented in seconds, rounded value of the `timestamp` column on `blocks` corresponding to the block the transaction was a part of.
+  UNIQUE (account, time)
+);
+-- To support binary search instead of sequential scan of active accounts.
+CREATE INDEX IF NOT EXISTS account_activeness_time ON account_activeness (time);
+
+-- Create table keeping track of contracts and the dates they have been part of a transations.
+CREATE TABLE IF NOT EXISTS contract_activeness (
+  contract INT8 NOT NULL REFERENCES contracts(id) ON DELETE RESTRICT ON UPDATE RESTRICT, -- dependant on inserts into `contracts_transactions`.
+  time INT8 NOT NULL, -- Date represented in seconds, rounded value of the `timestamp` column on `blocks` corresponding to the block the transaction was a part of.
+  UNIQUE (contract, time)
+);
+-- To support binary search instead of sequential scan of active contracts.
+CREATE INDEX IF NOT EXISTS contract_activeness_time ON contract_activeness (time);

--- a/kpi-tracker/resources/schema.sql
+++ b/kpi-tracker/resources/schema.sql
@@ -1,3 +1,18 @@
+-- Floors a (bigint) timestamp in seconds into date in seconds, e.g. 15/02/2022:14:00:00 -> 15/02/2022:00:00:00
+CREATE OR REPLACE FUNCTION date_seconds(t bigint)
+  RETURNS bigint
+  LANGUAGE plpgsql
+AS $$
+DECLARE
+  date bigint;
+BEGIN
+  SELECT floor((t)/86400)*86400::bigint
+  INTO date;
+
+  RETURN date;
+END;
+$$;
+
 -- All blocks. Mostly act as a time reference for other entities.
 CREATE TABLE IF NOT EXISTS blocks (
   id SERIAL8 PRIMARY KEY,


### PR DESCRIPTION
## Purpose

To make it more efficient to query for account and contract activeness, tables for both account and contract activeness are created, which consist of unique pairs of dates (represented in seconds) and references to accounts/contracts respectively.

**Querying 30 day activeness for accounts on a 90day time range**
Before: ~15 minutes (didn't time this, but it's a rough estimate)
After: ~5 seconds

## Changes

- Create tables (which are essentially "views" on data from other tables) to present daily activity for accounts/contracts
- Create indices on the time column for these views to support binary search

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
