### PR TITLE
Fix usage of addAgeInRange.

### DIFF
--- a/id-verifier/frontend/src/Root.tsx
+++ b/id-verifier/frontend/src/Root.tsx
@@ -243,10 +243,9 @@ function AgeInRange({ setStatement }: ExtendStatementProps) {
 
     const onClickAdd: MouseEventHandler<HTMLButtonElement> = () => {
         const builder = new IdStatementBuilder(false);
-        // Deliberately try to not do any validation for testing.
-        // If the value is not an integer then some part of the wallet pipeline should handle the error
-        // somewhat gracefully.
-        builder.addAgeInRange(lower as unknown as number, upper as unknown as number);
+        // Since addAgeInRange does some arithmetic we need to parse inputs as integers
+        // first. Otherwise we get unexpected behaviour.
+        builder.addAgeInRange(parseInt(lower), parseInt(upper));
         setStatement((oldStatements) => oldStatements.concat(builder.getStatement()));
     };
 


### PR DESCRIPTION
## Purpose

addAgeInRange is doing some arithmetic with upper bound now. So passing in strings leads to wrong behaviour.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.