### PR TITLE
Add value_delimiter param

### DIFF
--- a/chain-prometheus-exporter/CHANGELOG.md
+++ b/chain-prometheus-exporter/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased changes
+
+## 1.0.1
+
+- Change accounts input to be delimiting on ',' per default

--- a/chain-prometheus-exporter/CHANGELOG.md
+++ b/chain-prometheus-exporter/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 1.0.1
 
-- Change accounts input to be delimiting on ',' per default
+- Change accounts input to be delimiting on ','

--- a/chain-prometheus-exporter/Cargo.lock
+++ b/chain-prometheus-exporter/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chain-prometheus-exporter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/chain-prometheus-exporter/Cargo.toml
+++ b/chain-prometheus-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-prometheus-exporter"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chain-prometheus-exporter/src/main.rs
+++ b/chain-prometheus-exporter/src/main.rs
@@ -60,7 +60,8 @@ struct App {
     #[clap(
         long = "account",
         help = "List of account addresses to monitor.",
-        env = "CHAIN_PROMETHEUS_EXPORTER_ACCOUNTS"
+        env = "CHAIN_PROMETHEUS_EXPORTER_ACCOUNTS",
+        value_delimiter = ','
     )]
     accounts:        Vec<String>,
 }


### PR DESCRIPTION
## Purpose

According to the docs it states that: _CHAIN_PROMETHEUS_EXPORTER_ACCOUNTS the comma-separated list of strings in the form label:address where label is a valid prometheus label, and address is an account address._

Entering the following prior to change: 

```
❯ cargo run -- --account 'some_account_1:3qEzbyRuTo3CgWv6wCmyuhDiKzcNwWzRxaAjfEktw9rbPGtL1w,some_account_2:39oMXkk3Fjb3tMRNfvnnFxJZPF8ATmBdajyBv9gk7iSRMtZNqV'
   Compiling chain-prometheus-exporter v1.0.0 (/Users/lassemolleralm/Documents/Projects/concordium-misc-tools/chain-prometheus-exporter)
    Finished dev [unoptimized + debuginfo] target(s) in 2.24s
     Running `target/debug/chain-prometheus-exporter --account 'some_account_1:3qEzbyRuTo3CgWv6wCmyuhDiKzcNwWzRxaAjfEktw9rbPGtL1w,some_account_2:39oMXkk3Fjb3tMRNfvnnFxJZPF8ATmBdajyBv9gk7iSRMtZNqV'`
Error: Invalid Base58Check encoding.

Caused by:
    provided string contained invalid character ',' at byte 50
```

Entering the following post change: 

```
❯ cargo run -- --account 'some_account_1:3qEzbyRuTo3CgWv6wCmyuhDiKzcNwWzRxaAjfEktw9rbPGtL1w,some_account_2:39oMXkk3Fjb3tMRNfvnnFxJZPF8ATmBdajyBv9gk7iSRMtZNqV'
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/chain-prometheus-exporter --account 'some_account_1:3qEzbyRuTo3CgWv6wCmyuhDiKzcNwWzRxaAjfEktw9rbPGtL1w,some_account_2:39oMXkk3Fjb3tMRNfvnnFxJZPF8ATmBdajyBv9gk7iSRMtZNqV'`
2023-05-19T11:49:50.681677Z  INFO chain_prometheus_exporter: Tracking account 3qEzbyRuTo3CgWv6wCmyuhDiKzcNwWzRxaAjfEktw9rbPGtL1w with label some_account_1.
2023-05-19T11:49:50.682411Z  INFO chain_prometheus_exporter: Tracking account 39oMXkk3Fjb3tMRNfvnnFxJZPF8ATmBdajyBv9gk7iSRMtZNqV with label some_account_2.
```

Which is exactly what I expect. 

Also reasoning behind can be read at: https://docs.rs/clap/latest/clap/struct.Arg.html#method.value_delimiter

## Changes

Add https://docs.rs/clap/latest/clap/struct.Arg.html#method.value_delimiter character