### PR TITLE
wallet-connect-test-bench: Fix typecheck

### DIFF
--- a/wallet-connect-test-bench/front-end/src/writing_to_blockchain.ts
+++ b/wallet-connect-test-bench/front-end/src/writing_to_blockchain.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import { SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 import { AccountAddress, AccountTransactionType, CcdAmount, UpdateContractPayload } from '@concordium/web-sdk';
 import { WalletConnection } from '@concordium/react-components';
 import {
@@ -275,7 +276,7 @@ export async function setArray(
                 },
             ],
         },
-    ];
+    ] as SmartContractParameters;
 
     const schema = useModuleSchema
         ? {
@@ -300,9 +301,7 @@ export async function setArray(
             },
             receiveName,
             maxContractExecutionEnergy: 30000n,
-        } as UpdateContractPayload,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore:
+        },
         schema
     );
 }


### PR DESCRIPTION
TypeScript cannot infer that `inputParameter` is an array-case of `SmartContractParameters`, which in turn prevents it from inferring that `schema` has the correct type.

Adding a type assertion to `inputParameter` fixes this and thus the need for suppressing the `schema` type check.