### PR TITLE
Add link to source code

### DIFF
--- a/wallet-connect-test-bench/front-end/CHANGELOG.md
+++ b/wallet-connect-test-bench/front-end/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased changes
 
+- Add link to source code
 - Change that selected switch option is in bold font 
+
+## 1.2.0
+
 - Add `deploy`/`initialize` testing scenarios
 
 ## 1.0.0

--- a/wallet-connect-test-bench/front-end/package.json
+++ b/wallet-connect-test-bench/front-end/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test-bench-for-wallets",
     "packageManager": "yarn@3.2.0",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/wallet-connect-test-bench/front-end/src/Main.tsx
+++ b/wallet-connect-test-bench/front-end/src/Main.tsx
@@ -1041,6 +1041,19 @@ export default function Main(props: WalletConnectionProps) {
                                         </div>
                                     )}
                                 </TestBox>
+                                <br />
+                                <br />
+                                <div className="textCenter">
+                                    <a
+                                        href="https://github.com/Concordium/concordium-misc-tools/tree/main/wallet-connect-test-bench"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        Source code
+                                    </a>
+                                    <br />
+                                    <br />
+                                </div>
                             </div>
                         </>
                     )}


### PR DESCRIPTION
## Purpose

All hosted front ends should have a way to find the source code easily. Either through a link to an associated tutorial (that contains links to the source code) or if no tutorial exists through a link to the source code.

## Changes

Add link to source code.
