### PR TITLE
Change jsonRPC to gRPC in walletTestBench

### DIFF
--- a/wallet-connect-test-bench/front-end/CHANGELOG.md
+++ b/wallet-connect-test-bench/front-end/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-## 1.5.0
+## 1.4.1
 
 - Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
 

--- a/wallet-connect-test-bench/front-end/CHANGELOG.md
+++ b/wallet-connect-test-bench/front-end/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 1.5.0
+
+- Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
+
 ## 1.4.1
 
 - Add maxEnergy input field
@@ -11,8 +15,8 @@
 
 ## 1.2.0
 
-- Add `deploy`/`initialize` testing scenarios
+- Add `deploy`/`initialize` testing scenarios.
 
 ## 1.0.0
 
-- Initial wallet test bench with dApp libraries
+- Initial wallet test bench with dApp libraries.

--- a/wallet-connect-test-bench/front-end/CHANGELOG.md
+++ b/wallet-connect-test-bench/front-end/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-## 1.4.1
+## 1.5.0
 
 - Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
 

--- a/wallet-connect-test-bench/front-end/package.json
+++ b/wallet-connect-test-bench/front-end/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test-bench-for-wallets",
     "packageManager": "yarn@3.2.0",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/wallet-connect-test-bench/front-end/package.json
+++ b/wallet-connect-test-bench/front-end/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test-bench-for-wallets",
     "packageManager": "yarn@3.2.0",
-    "version": "1.5.0",
+    "version": "1.4.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/wallet-connect-test-bench/front-end/package.json
+++ b/wallet-connect-test-bench/front-end/package.json
@@ -10,7 +10,7 @@
         "@concordium/browser-wallet-api-helpers": "^2.4.0",
         "@concordium/react-components": "../../deps/concordium-dapp-libraries/packages/react-components",
         "@concordium/wallet-connectors": "../../deps/concordium-dapp-libraries/packages/wallet-connectors",
-        "@concordium/web-sdk": "^3.4.0",
+        "@concordium/web-sdk": "^6.0.0",
         "@walletconnect/types": "^2.1.4",
         "eslint": "^8.37.0",
         "moment": "^2.29.4",
@@ -20,7 +20,8 @@
     },
     "resolutions": {
         "@concordium/wallet-connectors": "../../deps/concordium-dapp-libraries/packages/wallet-connectors",
-        "@concordium/react-components": "../../deps/concordium-dapp-libraries/packages/react-components"
+        "@concordium/react-components": "../../deps/concordium-dapp-libraries/packages/react-components",
+        "@concordium/web-sdk": "^6.0.0"
     },
     "devDependencies": {
         "@craftamap/esbuild-plugin-html": "^0.4.0",

--- a/wallet-connect-test-bench/front-end/src/Main.tsx
+++ b/wallet-connect-test-bench/front-end/src/Main.tsx
@@ -526,6 +526,8 @@ export default function Main(props: WalletConnectionProps) {
                                                     .catch((e) => {
                                                         setReturnValueError((e as Error).message);
                                                     });
+                                            } else {
+                                                setReturnValueError('`grpcClient` is undefined');
                                             }
                                         }}
                                     >

--- a/wallet-connect-test-bench/front-end/src/Main.tsx
+++ b/wallet-connect-test-bench/front-end/src/Main.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, ChangeEvent, PropsWithChildren } from 'react';
 import Switch from 'react-switch';
 import { toBuffer, serializeTypeValue } from '@concordium/web-sdk';
-import { withJsonRpcClient, WalletConnectionProps, useConnection, useConnect } from '@concordium/react-components';
+import { useGrpcClient, WalletConnectionProps, useConnection, useConnect, TESTNET } from '@concordium/react-components';
 import { version } from '../package.json';
 import { WalletConnectionTypeButton } from './WalletConnectorTypeButton';
 
@@ -80,6 +80,7 @@ export default function Main(props: WalletConnectionProps) {
 
     const { connection, setConnection, account } = useConnection(connectedAccounts, genesisHashes);
     const { connect, isConnecting, connectError } = useConnect(activeConnector, setConnection);
+    const grpcClient = useGrpcClient(TESTNET);
 
     const [viewError, setViewError] = useState('');
     const [returnValueError, setReturnValueError] = useState('');
@@ -150,10 +151,10 @@ export default function Main(props: WalletConnectionProps) {
     // Refresh accountInfo periodically.
     // eslint-disable-next-line consistent-return
     useEffect(() => {
-        if (connection && account) {
+        if (grpcClient && account) {
             const interval = setInterval(() => {
                 console.log('refreshing1');
-                withJsonRpcClient(connection, (rpcClient) => accountInfo(rpcClient, account))
+                accountInfo(grpcClient, account)
                     .then((value) => {
                         if (value !== undefined) {
                             setAccountBalance(value.accountAmount.toString());
@@ -167,15 +168,15 @@ export default function Main(props: WalletConnectionProps) {
             }, REFRESH_INTERVAL.asMilliseconds());
             return () => clearInterval(interval);
         }
-    }, [connection, account]);
+    }, [grpcClient, account]);
 
     // Refresh smartContractInfo periodically.
     // eslint-disable-next-line consistent-return
     useEffect(() => {
-        if (connection) {
+        if (grpcClient) {
             const interval = setInterval(() => {
                 console.log('refreshing2');
-                withJsonRpcClient(connection, (rpcClient) => smartContractInfo(rpcClient))
+                smartContractInfo(grpcClient)
                     .then((value) => {
                         if (value !== undefined) {
                             setSmartContractBalance(value.amount.microCcdAmount.toString());
@@ -189,15 +190,15 @@ export default function Main(props: WalletConnectionProps) {
             }, REFRESH_INTERVAL.asMilliseconds());
             return () => clearInterval(interval);
         }
-    }, [connection, account]);
+    }, [grpcClient, account]);
 
     // Refresh view periodically.
     // eslint-disable-next-line consistent-return
     useEffect(() => {
-        if (connection && account) {
+        if (grpcClient && account) {
             const interval = setInterval(() => {
                 console.log('refreshing3');
-                withJsonRpcClient(connection, (rpcClient) => view(rpcClient))
+                view(grpcClient)
                     .then((value) => {
                         if (value !== undefined) {
                             setRecord(JSON.parse(value));
@@ -211,11 +212,11 @@ export default function Main(props: WalletConnectionProps) {
             }, REFRESH_INTERVAL.asMilliseconds());
             return () => clearInterval(interval);
         }
-    }, [connection, account]);
+    }, [grpcClient, account]);
 
     useEffect(() => {
-        if (connection && account) {
-            withJsonRpcClient(connection, (rpcClient) => accountInfo(rpcClient, account))
+        if (grpcClient && account) {
+            accountInfo(grpcClient, account)
                 .then((value) => {
                     if (value !== undefined) {
                         setAccountBalance(value.accountAmount.toString());
@@ -227,11 +228,11 @@ export default function Main(props: WalletConnectionProps) {
                     setAccountBalance('');
                 });
         }
-    }, [connection]);
+    }, [grpcClient]);
 
     useEffect(() => {
-        if (connection && account) {
-            withJsonRpcClient(connection, (rpcClient) => smartContractInfo(rpcClient))
+        if (grpcClient && account) {
+            smartContractInfo(grpcClient)
                 .then((value) => {
                     if (value !== undefined) {
                         setSmartContractBalance(value.amount.microCcdAmount.toString());
@@ -243,11 +244,11 @@ export default function Main(props: WalletConnectionProps) {
                     setSmartContractBalance('');
                 });
         }
-    }, [connection]);
+    }, [grpcClient]);
 
     useEffect(() => {
-        if (connection && account) {
-            withJsonRpcClient(connection, (rpcClient) => view(rpcClient))
+        if (grpcClient && account) {
+            view(grpcClient)
                 .then((value) => {
                     if (value !== undefined) {
                         setRecord(JSON.parse(value));
@@ -259,7 +260,7 @@ export default function Main(props: WalletConnectionProps) {
                     setRecord('');
                 });
         }
-    }, [connection]);
+    }, [grpcClient]);
 
     return (
         <main className="container">
@@ -515,17 +516,17 @@ export default function Main(props: WalletConnectionProps) {
                                         onClick={() => {
                                             setReturnValue('');
                                             setReturnValueError('');
-                                            withJsonRpcClient(connection, (rpcClient) =>
-                                                getValue(rpcClient, useModuleSchema, readDropDown)
-                                            )
-                                                .then((value) => {
-                                                    if (value !== undefined) {
-                                                        setReturnValue(JSON.stringify(value));
-                                                    }
-                                                })
-                                                .catch((e) => {
-                                                    setReturnValueError((e as Error).message);
-                                                });
+                                            if (grpcClient) {
+                                                getValue(grpcClient, useModuleSchema, readDropDown)
+                                                    .then((value) => {
+                                                        if (value !== undefined) {
+                                                            setReturnValue(JSON.stringify(value));
+                                                        }
+                                                    })
+                                                    .catch((e) => {
+                                                        setReturnValueError((e as Error).message);
+                                                    });
+                                            }
                                         }}
                                     >
                                         Get {readDropDown} value

--- a/wallet-connect-test-bench/front-end/src/Root.tsx
+++ b/wallet-connect-test-bench/front-end/src/Root.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { WithWalletConnector } from '@concordium/react-components';
+import { WithWalletConnector, TESTNET } from '@concordium/react-components';
 import Main from './Main';
-import { TESTNET } from './constants';
 
 /**
  * Connect to wallet, setup application state context, and render children when the wallet API is ready for use.

--- a/wallet-connect-test-bench/front-end/src/constants.ts
+++ b/wallet-connect-test-bench/front-end/src/constants.ts
@@ -1,7 +1,6 @@
 import {
     BrowserWalletConnector,
     ephemeralConnectorType,
-    Network,
     WalletConnectConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
 } from '@concordium/react-components';
@@ -9,9 +8,6 @@ import { SignClientTypes } from '@walletconnect/types';
 import moment from 'moment';
 
 export const REFRESH_INTERVAL = moment.duration(10, 'seconds');
-
-// The TESTNET_GENESIS_BLOCK_HASH is used to check that the user has its browser wallet connected to testnet and not to mainnet.
-export const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
 
 // The 'PARAMETER'/'RETURN_VALUE' schemas are created by running the command `cargo concordium --schema-json-out ./` in the `smart-contract` folder.
 // This produces an output file in the same folder which those schemas.
@@ -96,12 +92,6 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
         url: '#',
         icons: ['https://walletconnect.com/walletconnect-logo.png'],
     },
-};
-export const TESTNET: Network = {
-    name: 'testnet',
-    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
-    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
 };
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);

--- a/wallet-connect-test-bench/front-end/src/reading_from_blockchain.ts
+++ b/wallet-connect-test-bench/front-end/src/reading_from_blockchain.ts
@@ -1,4 +1,10 @@
-import { toBuffer, JsonRpcClient, deserializeTypeValue, deserializeReceiveReturnValue } from '@concordium/web-sdk';
+import {
+    toBuffer,
+    deserializeTypeValue,
+    deserializeReceiveReturnValue,
+    ConcordiumGRPCClient,
+    AccountAddress,
+} from '@concordium/web-sdk';
 
 import {
     CONTRACT_NAME,
@@ -19,7 +25,7 @@ import {
     BASE_64_SCHEMA,
 } from './constants';
 
-export async function getValue(rpcClient: JsonRpcClient, useModuleSchema: boolean, dropDown: string) {
+export async function getValue(rpcClient: ConcordiumGRPCClient, useModuleSchema: boolean, dropDown: string) {
     let entrypointName = `${CONTRACT_NAME}.get_u8`;
 
     switch (dropDown) {
@@ -150,7 +156,7 @@ export async function getValue(rpcClient: JsonRpcClient, useModuleSchema: boolea
     }
 }
 
-export async function view(rpcClient: JsonRpcClient) {
+export async function view(rpcClient: ConcordiumGRPCClient) {
     const res = await rpcClient.invokeContract({
         method: `${CONTRACT_NAME}.view`,
         contract: { index: CONTRACT_INDEX, subindex: CONTRACT_SUB_INDEX },
@@ -173,10 +179,10 @@ export async function view(rpcClient: JsonRpcClient) {
     }
 }
 
-export async function accountInfo(rpcClient: JsonRpcClient, account: string) {
-    return rpcClient.getAccountInfo(account);
+export async function accountInfo(rpcClient: ConcordiumGRPCClient, account: string) {
+    return rpcClient.getAccountInfo(new AccountAddress(account));
 }
 
-export async function smartContractInfo(rpcClient: JsonRpcClient) {
+export async function smartContractInfo(rpcClient: ConcordiumGRPCClient) {
     return rpcClient.getInstanceInfo({ index: CONTRACT_INDEX, subindex: CONTRACT_SUB_INDEX });
 }

--- a/wallet-connect-test-bench/front-end/yarn.lock
+++ b/wallet-connect-test-bench/front-end/yarn.lock
@@ -251,7 +251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/browser-wallet-api-helpers@npm:^2.4.0":
+"@concordium/browser-wallet-api-helpers@npm:^2.4.0, @concordium/browser-wallet-api-helpers@npm:^2.5.0":
   version: 2.5.0
   resolution: "@concordium/browser-wallet-api-helpers@npm:2.5.0"
   dependencies:
@@ -281,13 +281,13 @@ __metadata:
   linkType: hard
 
 "@concordium/react-components@file:../../deps/concordium-dapp-libraries/packages/react-components::locator=test-bench-for-wallets%40workspace%3A.":
-  version: 0.2.1
-  resolution: "@concordium/react-components@file:../../deps/concordium-dapp-libraries/packages/react-components#../../deps/concordium-dapp-libraries/packages/react-components::hash=317d58&locator=test-bench-for-wallets%40workspace%3A."
+  version: 0.3.0
+  resolution: "@concordium/react-components@file:../../deps/concordium-dapp-libraries/packages/react-components#../../deps/concordium-dapp-libraries/packages/react-components::hash=a49798&locator=test-bench-for-wallets%40workspace%3A."
   dependencies:
-    "@concordium/wallet-connectors": ^0.2.1
+    "@concordium/wallet-connectors": ^0.3.1
   peerDependencies:
     react: ^18
-  checksum: 6cf53b6501e8163b73b5675434155d7fafeae4e85c23728ac4f95c9e76bf18df99bdfa5d911789845f44c517a9cb52bab6a8698ded47f071dbc1ea3c2b54228e
+  checksum: 5fb7680394b61708ff06f8e98611bc208110cfe369fe7f9200e681ee08f410b60781d88b67b70db934fc6e1ef847bf98656b8835452d0de1d15b91fc75d27afa
   languageName: node
   linkType: hard
 
@@ -299,13 +299,13 @@ __metadata:
   linkType: hard
 
 "@concordium/wallet-connectors@file:../../deps/concordium-dapp-libraries/packages/wallet-connectors::locator=test-bench-for-wallets%40workspace%3A.":
-  version: 0.2.3
-  resolution: "@concordium/wallet-connectors@file:../../deps/concordium-dapp-libraries/packages/wallet-connectors#../../deps/concordium-dapp-libraries/packages/wallet-connectors::hash=ca6e47&locator=test-bench-for-wallets%40workspace%3A."
+  version: 0.3.1
+  resolution: "@concordium/wallet-connectors@file:../../deps/concordium-dapp-libraries/packages/wallet-connectors#../../deps/concordium-dapp-libraries/packages/wallet-connectors::hash=d65759&locator=test-bench-for-wallets%40workspace%3A."
   dependencies:
-    "@concordium/browser-wallet-api-helpers": ^2.4.0
+    "@concordium/browser-wallet-api-helpers": ^2.5.0
     "@walletconnect/qrcode-modal": ^1.8.0
     "@walletconnect/sign-client": ^2.1.4
-  checksum: b82b9d7f8ed5365946d7df8ed1484a7b5c99c293afcc38eaab75673fa0e131416247bcdb26dd8538a504eec22f6e38642554991e56bde3659c0afc662ac0147a
+  checksum: 530be3a02f58380d7981015df90a8393dc46f16bad02ce719b9d9665e604a1762ebb6f08ed428fc0a63a86b9e741c16938ec66ee5319fdc3e06938c0de1a8e70
   languageName: node
   linkType: hard
 

--- a/wallet-connect-test-bench/front-end/yarn.lock
+++ b/wallet-connect-test-bench/front-end/yarn.lock
@@ -260,11 +260,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@npm:6.5.0":
-  version: 6.5.0
-  resolution: "@concordium/common-sdk@npm:6.5.0"
+"@concordium/common-sdk@npm:9.0.0":
+  version: 9.0.0
+  resolution: "@concordium/common-sdk@npm:9.0.0"
   dependencies:
-    "@concordium/rust-bindings": 0.11.1
+    "@concordium/rust-bindings": 1.1.0
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/runtime-rpc": ^2.8.2
@@ -276,7 +276,7 @@ __metadata:
     iso-3166-1: ^2.1.1
     json-bigint: ^1.0.0
     uuid: ^8.3.2
-  checksum: daf7e586b5fd89a4f2e84c602b9ffdbe5215a176b6673aa42abf7c54d722f5380f716672100f6a68c321ba97b87c381476bce768ff1e5299b5d07c6ded96e716
+  checksum: b640846415dfb18b4bb549519ab7fa7825c6b5e84adf1cfaeeea89bb54341e5176e71f00b732ea9bb375aac938842434ab1d6d5ffe2a5f360efc236ea5b0ef4a
   languageName: node
   linkType: hard
 
@@ -291,10 +291,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/rust-bindings@npm:0.11.1":
-  version: 0.11.1
-  resolution: "@concordium/rust-bindings@npm:0.11.1"
-  checksum: fe1bbcd0a98a7e148cfe9fa5ec69a693b19608b64b01723aedd9a7616958d5069cef006f8dfa610f7fad3cd3e8d356c99c76ff2606ea44d90138a43897118277
+"@concordium/rust-bindings@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@concordium/rust-bindings@npm:1.1.0"
+  checksum: 4890306b5df5fb85012cc6c6a6daf15ec1d24c528ac487a4547e8758738a1205b2386a1d4b015dc45312811466d853819edff4b9921d3674afe13ade5cacc061
   languageName: node
   linkType: hard
 
@@ -309,17 +309,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/web-sdk@npm:^3.4.0, @concordium/web-sdk@npm:^3.4.2":
-  version: 3.5.0
-  resolution: "@concordium/web-sdk@npm:3.5.0"
+"@concordium/web-sdk@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@concordium/web-sdk@npm:6.0.0"
   dependencies:
-    "@concordium/common-sdk": 6.5.0
-    "@concordium/rust-bindings": 0.11.1
+    "@concordium/common-sdk": 9.0.0
+    "@concordium/rust-bindings": 1.1.0
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     buffer: ^6.0.3
     process: ^0.11.10
-  checksum: 681cfdb2533bba93ac62f44b0fcf5596a0fd89a5895085e3e6a416fa162bc1d22ac3bc1a6f8b89a196c46e89e9fd6401c25c493079f406bf8dfa9c6a7eb0aaa7
+  checksum: 23cfda2813ed86ed165f427edab237e5c20af70405d450541479294a1093b60843ce9d7f8a2dbeb69e174e0aed0ec51bee109e0fb7e22f121bff5c11c4bb24de
   languageName: node
   linkType: hard
 
@@ -7819,7 +7819,7 @@ send@latest:
     "@concordium/browser-wallet-api-helpers": ^2.4.0
     "@concordium/react-components": ../../deps/concordium-dapp-libraries/packages/react-components
     "@concordium/wallet-connectors": ../../deps/concordium-dapp-libraries/packages/wallet-connectors
-    "@concordium/web-sdk": ^3.4.0
+    "@concordium/web-sdk": ^6.0.0
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@types/node": ^18.7.23
     "@types/react": ^18.0.9


### PR DESCRIPTION
## Purpose

JSON-RPC is deprecated and will be eventually removed from all our libraries. This PR migrates the wallet test bench dApp.

## Changes

- Replace using jsonRPC with gRPC
