### PR TITLE
[KPI Tracker] Delegation-related graphs

### DIFF
--- a/kpi-tracker/CHANGELOG.md
+++ b/kpi-tracker/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Split transaction graphs into separate types of transactions.
 - Add graph for accounts with CCD transfers.
-- Add graph for number of active bakers.
 - Add graph for number of active finalizers.
+- Add graph showing active staking accounts, divided into bakers and delegators.
 
 ## 1.1.0
 

--- a/kpi-tracker/CHANGELOG.md
+++ b/kpi-tracker/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add graph for accounts with CCD transfers.
 - Add graph for number of active finalizers.
 - Add graph showing active staking accounts, divided into bakers and delegators.
+- Add graph showing status of active bakers.
+- Add graph of delegation recipients.
 
 ## 1.1.0
 

--- a/kpi-tracker/grafana/dashboard.json
+++ b/kpi-tracker/grafana/dashboard.json
@@ -56,7 +56,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 40,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -97,7 +97,38 @@
           },
           "unit": "CCD"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "baker_equity"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "delegated_stake"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -127,7 +158,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__unixEpochGroup(timestamp, $__interval) AS time,\n  paydays.total_stake::DECIMAL/1000000 as stake_ccd\nFROM blocks\nJOIN paydays ON paydays.block = blocks.id;",
+          "rawSql": "SELECT\n  paydays.total_equity_capital::DECIMAL/1000000 AS baker_equity,\n  paydays.total_delegated_stake::DECIMAL/1000000 AS delegated_stake,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM blocks\nJOIN paydays ON paydays.block = blocks.id;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1722,6 +1753,6 @@
   "timezone": "",
   "title": "KPI tracker",
   "uid": "8dm2sVA4k",
-  "version": 14,
+  "version": 17,
   "weekStart": ""
 }

--- a/kpi-tracker/grafana/dashboard.json
+++ b/kpi-tracker/grafana/dashboard.json
@@ -397,7 +397,52 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "open_for_new"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "closed_for_new"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "closed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -1761,7 +1806,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1871,7 +1917,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1951,7 +1998,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": false,
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -2020,6 +2067,6 @@
   "timezone": "",
   "title": "KPI tracker",
   "uid": "8dm2sVA4k",
-  "version": 22,
+  "version": 23,
   "weekStart": ""
 }

--- a/kpi-tracker/grafana/dashboard.json
+++ b/kpi-tracker/grafana/dashboard.json
@@ -128,7 +128,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  paydays.pool_reward::DECIMAL/1000000 as baker_rewards,\n  paydays.finalizer_reward::DECIMAL/1000000 as finalizer_rewards,\n  paydays.foundation_reward::DECIMAL/1000000 as foundation_charge,\n  $__unixEpochGroup(blocks.timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks on blocks.id = paydays.block;",
+          "rawSql": "SELECT\n  paydays.pool_reward::DECIMAL/1000000 as validator_rewards,\n  paydays.finalizer_reward::DECIMAL/1000000 as finalizer_rewards,\n  paydays.foundation_reward::DECIMAL/1000000 as foundation_charge,\n  $__unixEpochGroup(blocks.timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks on blocks.id = paydays.block;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -239,7 +239,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH data AS (\n  SELECT\n    paydays.pool_reward::DECIMAL/1000000 as baker_rewards,\n    paydays.finalizer_reward::DECIMAL/1000000 as finalizer_rewards,\n    paydays.foundation_reward::DECIMAL/1000000 as foundation_charge,\n    $__unixEpochGroup(blocks.timestamp, $__interval) AS time\n  FROM paydays\n  JOIN blocks on blocks.id = paydays.block\n)\n\nSELECT\n  SUM(baker_rewards) OVER (ORDER BY time ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS baker_rewards,\n  SUM(finalizer_rewards) OVER (ORDER BY time ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS finalizer_rewards,\n  SUM(foundation_charge) OVER (ORDER BY time ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS foundation_charge,\n  time\nFROM data;",
+          "rawSql": "WITH data AS (\n  SELECT\n    paydays.pool_reward::DECIMAL/1000000 as validator_rewards,\n    paydays.finalizer_reward::DECIMAL/1000000 as finalizer_rewards,\n    paydays.foundation_reward::DECIMAL/1000000 as foundation_charge,\n    $__unixEpochGroup(blocks.timestamp, $__interval) AS time\n  FROM paydays\n  JOIN blocks on blocks.id = paydays.block\n)\n\nSELECT\n  SUM(validator_rewards) OVER (ORDER BY time ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS validator_rewards,\n  SUM(finalizer_rewards) OVER (ORDER BY time ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS finalizer_rewards,\n  SUM(foundation_charge) OVER (ORDER BY time ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS foundation_charge,\n  time\nFROM data;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -288,7 +288,7 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -448,7 +448,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "baker_equity"
+              "options": "validator_equity"
             },
             "properties": [
               {
@@ -463,7 +463,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "actively_delegated"
+              "options": "delegated_to_pool"
             },
             "properties": [
               {
@@ -520,7 +520,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  paydays.total_equity_capital::DECIMAL/1000000 AS baker_equity,\n  paydays.total_actively_delegated::DECIMAL/1000000 AS actively_delegated,\n  paydays.total_passively_delegated::DECIMAL/1000000 AS passively_delegated,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM blocks\nJOIN paydays ON paydays.block = blocks.id;",
+          "rawSql": "SELECT\n  paydays.total_equity_capital::DECIMAL/1000000 AS validator_equity,\n  paydays.total_actively_delegated::DECIMAL/1000000 AS delegated_to_pool,\n  paydays.total_passively_delegated::DECIMAL/1000000 AS passively_delegated,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM blocks\nJOIN paydays ON paydays.block = blocks.id;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -662,7 +662,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  paydays.num_bakers as bakers,\n  paydays.num_delegators as delegators,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
+          "rawSql": "SELECT\n  paydays.num_pools as staking_pools,\n  paydays.num_delegators as delegators,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -691,6 +691,7 @@
         "type": "postgres",
         "uid": "${postgres_db}"
       },
+      "description": "Note: this counts all registered pools, not only pools that participated in a reward period, so the total may be slightly inconsistent with the \"Active staking accounts\" graph.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -703,7 +704,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 20,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -711,7 +712,7 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -721,7 +722,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -817,7 +818,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  paydays.num_open_bakers as open_for_new,\n  paydays.num_bakers - paydays.num_open_bakers - paydays.num_closed_bakers as closed_for_new,\n  paydays.num_closed_bakers as closed,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
+          "rawSql": "SELECT\n  paydays.num_open_pools as open_for_new,\n  paydays.num_closed_for_new_pools as closed_for_new,\n  paydays.num_closed_pools as closed,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -838,7 +839,7 @@
           }
         }
       ],
-      "title": "Active baker status",
+      "title": "Staking pool status",
       "type": "timeseries"
     },
     {
@@ -2410,6 +2411,6 @@
   "timezone": "",
   "title": "KPI tracker",
   "uid": "8dm2sVA4k",
-  "version": 29,
+  "version": 31,
   "weekStart": ""
 }

--- a/kpi-tracker/grafana/dashboard.json
+++ b/kpi-tracker/grafana/dashboard.json
@@ -76,7 +76,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -2020,6 +2020,6 @@
   "timezone": "",
   "title": "KPI tracker",
   "uid": "8dm2sVA4k",
-  "version": 20,
+  "version": 22,
   "weekStart": ""
 }

--- a/kpi-tracker/grafana/dashboard.json
+++ b/kpi-tracker/grafana/dashboard.json
@@ -895,7 +895,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 40,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -913,7 +913,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -937,25 +937,31 @@
         },
         "overrides": [
           {
-            "__systemRef": "hideSeriesFrom",
             "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "active_bakers"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
+              "id": "byName",
+              "options": "active_bakers"
             },
             "properties": [
               {
-                "id": "custom.hideFrom",
+                "id": "color",
                 "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "active_delegators"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
                 }
               }
             ]
@@ -990,7 +996,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  paydays.num_bakers as active_bakers,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
+          "rawSql": "SELECT\n  paydays.num_bakers as active_bakers,\n  paydays.num_delegators as active_delegators,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1011,7 +1017,7 @@
           }
         }
       ],
-      "title": "Active Bakers",
+      "title": "Active Staking Accounts",
       "type": "timeseries"
     },
     {
@@ -1716,6 +1722,6 @@
   "timezone": "",
   "title": "KPI tracker",
   "uid": "8dm2sVA4k",
-  "version": 13,
+  "version": 14,
   "weekStart": ""
 }

--- a/kpi-tracker/grafana/dashboard.json
+++ b/kpi-tracker/grafana/dashboard.json
@@ -29,6 +29,7 @@
   "liveNow": false,
   "panels": [
     {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -36,7 +37,8 @@
         "y": 0
       },
       "id": 19,
-      "title": "Misc",
+      "panels": [],
+      "title": "Staking",
       "type": "row"
     },
     {
@@ -56,7 +58,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 40,
+            "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -116,7 +118,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "delegated_stake"
+              "options": "actively_delegated"
             },
             "properties": [
               {
@@ -127,11 +129,26 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "passively_delegated"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 0,
         "y": 1
@@ -158,7 +175,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  paydays.total_equity_capital::DECIMAL/1000000 AS baker_equity,\n  paydays.total_delegated_stake::DECIMAL/1000000 AS delegated_stake,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM blocks\nJOIN paydays ON paydays.block = blocks.id;",
+          "rawSql": "SELECT\n  paydays.total_equity_capital::DECIMAL/1000000 AS baker_equity,\n  paydays.total_actively_delegated::DECIMAL/1000000 AS actively_delegated,\n  paydays.total_passively_delegated::DECIMAL/1000000 AS passively_delegated,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM blocks\nJOIN paydays ON paydays.block = blocks.id;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -183,11 +200,405 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "postgres",
+        "uid": "${postgres_db}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bakers"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "delegators"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "${postgres_db}"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  paydays.num_bakers as bakers,\n  paydays.num_delegators as delegators,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Active staking accounts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "${postgres_db}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "${postgres_db}"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  paydays.num_open_bakers as open_for_new,\n  paydays.num_bakers - paydays.num_open_bakers - paydays.num_closed_bakers as closed_for_new,\n  paydays.num_closed_bakers as closed,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Active baker status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "${postgres_db}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "open_for_new"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "closed_for_new"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "${postgres_db}"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  paydays.num_open_delegation_recipients as open_for_new,\n  paydays.num_closed_for_new_delegation_recipients as closed_for_new,\n  $__unixEpochGroup(blocks.timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Delegation recipients",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 17
       },
       "id": 17,
       "title": "Entities",
@@ -257,7 +668,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 11
+        "y": 18
       },
       "id": 28,
       "options": {
@@ -393,7 +804,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 11
+        "y": 18
       },
       "id": 29,
       "options": {
@@ -527,7 +938,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 28
       },
       "id": 3,
       "options": {
@@ -640,7 +1051,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 28
       },
       "id": 7,
       "options": {
@@ -691,7 +1102,7 @@
     {
       "datasource": {
         "type": "postgres",
-        "uid": "d4ab35f1-5c8e-48b6-8566-37f813b41e94"
+        "uid": "${postgres_db}"
       },
       "fieldConfig": {
         "defaults": {
@@ -750,7 +1161,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 37
       },
       "id": 30,
       "options": {
@@ -861,7 +1272,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 37
       },
       "id": 26,
       "options": {
@@ -907,148 +1318,6 @@
         }
       ],
       "title": "Smart contracts (modules)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "postgres",
-        "uid": "${postgres_db}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 40,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepAfter",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "active_bakers"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "active_delegators"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 38
-      },
-      "id": 31,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "postgres",
-            "uid": "${postgres_db}"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  paydays.num_bakers as active_bakers,\n  paydays.num_delegators as active_delegators,\n  $__unixEpochGroup(timestamp, $__interval) AS time\nFROM paydays\nJOIN blocks ON blocks.id = paydays.block;",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Active Staking Accounts",
       "type": "timeseries"
     },
     {
@@ -1138,8 +1407,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 38
+        "x": 0,
+        "y": 45
       },
       "id": 32,
       "options": {
@@ -1193,7 +1462,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 53
       },
       "id": 15,
       "panels": [],
@@ -1264,7 +1533,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 54
       },
       "id": 13,
       "options": {
@@ -1390,7 +1659,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 54
       },
       "id": 5,
       "options": {
@@ -1492,8 +1761,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1509,7 +1777,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 56
+        "y": 63
       },
       "id": 11,
       "options": {
@@ -1603,8 +1871,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1635,7 +1902,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 56
+        "y": 63
       },
       "id": 21,
       "options": {
@@ -1684,7 +1951,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -1753,6 +2020,6 @@
   "timezone": "",
   "title": "KPI tracker",
   "uid": "8dm2sVA4k",
-  "version": 17,
+  "version": 20,
   "weekStart": ""
 }

--- a/kpi-tracker/resources/schema.sql
+++ b/kpi-tracker/resources/schema.sql
@@ -34,7 +34,8 @@ CREATE INDEX IF NOT EXISTS blocks_timestamp ON blocks (timestamp);
 -- All payday blocks (only exists for protocol version 4 and onwards).
 CREATE TABLE IF NOT EXISTS paydays (
   block INT8 PRIMARY KEY REFERENCES blocks(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  total_stake INT8 NOT NULL,
+  total_equity_capital INT8 NOT NULL,
+  total_delegated_stake INT8 NOT NULL,
   num_bakers INT8 NOT NULL,
   num_finalizers INT8 NOT NULL,
   num_delegators INT8 NOT NULL

--- a/kpi-tracker/resources/schema.sql
+++ b/kpi-tracker/resources/schema.sql
@@ -35,8 +35,13 @@ CREATE INDEX IF NOT EXISTS blocks_timestamp ON blocks (timestamp);
 CREATE TABLE IF NOT EXISTS paydays (
   block INT8 PRIMARY KEY REFERENCES blocks(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
   total_equity_capital INT8 NOT NULL,
-  total_delegated_stake INT8 NOT NULL,
+  total_passively_delegated INT8 NOT NULL,
+  total_actively_delegated INT8 NOT NULL,
   num_bakers INT8 NOT NULL,
+  num_open_bakers INT8 NOT NULL,
+  num_closed_bakers INT8 NOT NULL,
+  num_open_delegation_recipients INT8 NOT NULL,
+  num_closed_for_new_delegation_recipients INT8 NOT NULL,
   num_finalizers INT8 NOT NULL,
   num_delegators INT8 NOT NULL
 );

--- a/kpi-tracker/resources/schema.sql
+++ b/kpi-tracker/resources/schema.sql
@@ -41,9 +41,14 @@ CREATE TABLE IF NOT EXISTS paydays (
   pool_reward INT8 NOT NULL,
   finalizer_reward INT8 NOT NULL,
   foundation_reward INT8 NOT NULL,
-  num_bakers INT8 NOT NULL,
-  num_open_bakers INT8 NOT NULL,
-  num_closed_bakers INT8 NOT NULL,
+  -- Number of staking pools active in the preceding payday period.
+  num_pools INT8 NOT NULL,
+  -- Note: This is a snapshot of the number of open pools at the time of the payday block, i.e. NOT directly related to the number of staking pools for the preceding payday period (`num_pools`).
+  num_open_pools INT8 NOT NULL,
+  -- Same as above.
+  num_closed_for_new_pools INT8 NOT NULL,
+  -- Same as above.
+  num_closed_pools INT8 NOT NULL,
   num_delegation_recipients INT8 NOT NULL,
   num_finalizers INT8 NOT NULL,
   num_delegators INT8 NOT NULL

--- a/kpi-tracker/resources/schema.sql
+++ b/kpi-tracker/resources/schema.sql
@@ -36,7 +36,8 @@ CREATE TABLE IF NOT EXISTS paydays (
   block INT8 PRIMARY KEY REFERENCES blocks(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
   total_stake INT8 NOT NULL,
   num_bakers INT8 NOT NULL,
-  num_finalizers INT8 NOT NULL
+  num_finalizers INT8 NOT NULL,
+  num_delegators INT8 NOT NULL
 );
 
 -- All accounts created.


### PR DESCRIPTION
## Purpose

Addresses #96, #97, #99, #100, and #101.

## Changes

- The graph for active bakers is now "Active staking accounts" and shows bakers and delegators stacked.
- The staked CCD graph has been split into baker equity, actively delegated, and passively delegated.
- A new graph that shows the status of active bakers (i.e. open, closed, closed for new).
- A new graph that plots the number of bakers being delegated to.

To accomplish this, quite a few column were added to the `paydays` table.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.