### PR TITLE
Fix save file extension on Windows

### DIFF
--- a/company-id-gui/package.json
+++ b/company-id-gui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "company-id-gui",
     "private": true,
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/company-id-gui/src-tauri/Cargo.lock
+++ b/company-id-gui/src-tauri/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "company-id-gui"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/company-id-gui/src-tauri/Cargo.toml
+++ b/company-id-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "company-id-gui"
-version = "1.0.0"
+version = "1.0.1"
 description = "Concordium Company ID GUI"
 authors = ["Concordium <developers@concordium.com>"]
 license = "Apache-2.0"

--- a/company-id-gui/src-tauri/src/main.rs
+++ b/company-id-gui/src-tauri/src/main.rs
@@ -197,7 +197,7 @@ async fn set_node_and_network(
         return Err(Error::NotCaughtUp);
     }
 
-    * state.node.lock().await = Some(client);
+    *state.node.lock().await = Some(client);
     *state.net.lock().await = Some(net);
 
     Ok(())
@@ -254,7 +254,8 @@ async fn save_request_file(state: tauri::State<'_, State>, net: Net) -> Result<(
 
     let mut file_builder = FileDialogBuilder::new()
         .set_file_name("request.json")
-        .set_title("Save request file");
+        .set_title("Save request file")
+        .add_filter("JSON", &["json"]);
     if let Ok(cd) = std::env::current_dir() {
         file_builder = file_builder.set_directory(cd);
     } else {
@@ -440,6 +441,7 @@ async fn create_account(
     let Some(path) = FileDialogBuilder::new()
         .set_file_name("account-keys.json")
         .set_title("Save account key file")
+        .add_filter("JSON", &["json"])
         .save_file()
     else {
         return Ok(account);
@@ -590,6 +592,7 @@ async fn save_keys(
     let Some(path) = FileDialogBuilder::new()
         .set_file_name("account-keys.json")
         .set_title("Save account key file")
+        .add_filter("JSON", &["json"])
         .save_file()
     else {
         return Ok(());
@@ -720,6 +723,7 @@ async fn generate_recovery_request(
     let Some(path) = FileDialogBuilder::new()
         .set_file_name("recovery-request.json")
         .set_title("Save recovery request file")
+        .add_filter("JSON", &["json"])
         .save_file()
     else {
         return Ok(());


### PR DESCRIPTION
## Purpose

If the user changes the name of any of the saved files Windows will remove the JSON file extension. This PR fixes this.

## Changes

Adding a "file extension filter" fixes the issue.