### PR TITLE
Fix wrong network error message

### DIFF
--- a/company-id-gui/package.json
+++ b/company-id-gui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "company-id-gui",
     "private": true,
-    "version": "1.0.1",
+    "version": "1.0.2",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/company-id-gui/src-tauri/Cargo.lock
+++ b/company-id-gui/src-tauri/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "company-id-gui"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/company-id-gui/src-tauri/Cargo.toml
+++ b/company-id-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "company-id-gui"
-version = "1.0.1"
+version = "1.0.2"
 description = "Concordium Company ID GUI"
 authors = ["Concordium <developers@concordium.com>"]
 license = "Apache-2.0"

--- a/company-id-gui/src-tauri/src/main.rs
+++ b/company-id-gui/src-tauri/src/main.rs
@@ -131,7 +131,7 @@ enum Error {
     #[error("Failed to create file: {0}")]
     FileError(#[from] Box<dyn std::error::Error>),
     #[error("Node is not on the {0} network.")]
-    WrongNetwork(Net),
+    WrongNetwork(&'static str),
     #[error("Node is not caught up. Please try again later.")]
     NotCaughtUp,
     #[error("Invalid identity object: {0}")]
@@ -184,7 +184,10 @@ async fn set_node_and_network(
         Net::Testnet => TESTNET_GENESIS_HASH,
     };
     if genesis_hash.to_string() != expected_genesis_hash {
-        return Err(Error::WrongNetwork(net));
+        match net {
+            Net::Mainnet => return Err(Error::WrongNetwork("Mainnet")),
+            Net::Testnet => return Err(Error::WrongNetwork("Testnet")),
+        }
     }
 
     let time_since_last_finalized = client


### PR DESCRIPTION
## Purpose

The error message when selected network and node URL do not match prints the net code of the network instead of the name of the network. This PR fixes this.
