### PR TITLE
Stop wCCD generator minting for everyone too fast

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Unreleased changes
+## 1.1.1
 
-- Stop `wccd` mode from minting to everyone faster than the specified TPS.
+Stop `wccd` mode from minting to everyone faster than the specified TPS.
 
 ## 1.1.0
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased changes
+
+- Stop `wccd` mode from minting to everyone faster than the specified TPS.
+
 ## 1.1.0
 
 Support protocol 6 and node version 6.

--- a/generator/Cargo.lock
+++ b/generator/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,17 +1,20 @@
 [package]
 name = "generator"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 concordium-rust-sdk = { path = "../deps/concordium-rust-sdk", version = "*" }
-clap = {version = "4", features = ["derive", "color"] }
+clap = { version = "4", features = ["derive", "color"] }
 anyhow = "1"
-chrono = {version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 rand = "0.7"
-tokio = {version = "1.27", features = ["rt-multi-thread", "macros", "time"]}
-tonic = {version = "0.8", features = ["tls", "tls-roots"]} # Use system trust roots.
+tokio = { version = "1.27", features = ["rt-multi-thread", "macros", "time"] }
+tonic = { version = "0.8", features = [
+    "tls",
+    "tls-roots",
+] } # Use system trust roots.
 futures = "0.3.28"
 http = "0.2.9"
 serde_json = "1.0.96"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -6,15 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 concordium-rust-sdk = { path = "../deps/concordium-rust-sdk", version = "*" }
-clap = { version = "4", features = ["derive", "color"] }
+clap = {version = "4", features = ["derive", "color"] }
 anyhow = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = {version = "0.4", features = ["serde"] }
 rand = "0.7"
-tokio = { version = "1.27", features = ["rt-multi-thread", "macros", "time"] }
-tonic = { version = "0.8", features = [
-    "tls",
-    "tls-roots",
-] } # Use system trust roots.
+tokio = {version = "1.27", features = ["rt-multi-thread", "macros", "time"]}
+tonic = {version = "0.8", features = ["tls", "tls-roots"]} # Use system trust roots.
 futures = "0.3.28"
 http = "0.2.9"
 serde_json = "1.0.96"

--- a/generator/README.md
+++ b/generator/README.md
@@ -69,7 +69,7 @@ The transactions are sent in a round robin fashion.
 
 ### `wccd`
 
-The tool first deploys and initializes the [`cis2-wccd`](https://github.com/Concordium/concordium-rust-smart-contracts/tree/fcc668d87207aaf07b43f5a3b02b6d0a634368d0/examples/cis2-wccd) example contract. It then mints 1 (micro) wCCD for each account on the chain in order to increase the size of the state of the contract. The transactions alternate between wrapping, transferring, and unwrapping wCCD. In each case the receiver is the sender, since it is simple and there is no special handling of this in the contract.
+The tool first deploys and initializes the [`cis2-wccd`](https://github.com/Concordium/concordium-rust-smart-contracts/tree/fcc668d87207aaf07b43f5a3b02b6d0a634368d0/examples/cis2-wccd) example contract. It then starts minting 1 (micro) wCCD for each account on the chain in order to increase the size of the state of the contract. After that, the transactions alternate between wrapping, transferring, and unwrapping wCCD. In each case the receiver is the sender, since it is simple and there is no special handling of this in the contract.
 
 ### `register-credentials`
 


### PR DESCRIPTION
## Purpose

Addresses #107.

## Changes

The initial minting of wCCD is moved from the instantiation to the generator.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.