### PR TITLE
Curl to recover-id-object

### DIFF
--- a/recover-id-object/scripts/Dockerfile
+++ b/recover-id-object/scripts/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /usr/app/recover-id-object/target/release/recover-id-object ./
 
 RUN apt-get update && \
     apt-get -y install \
-      ca-certificates \
+      ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN chmod +x recover-id-object

--- a/recover-id-object/scripts/Dockerfile
+++ b/recover-id-object/scripts/Dockerfile
@@ -16,6 +16,7 @@ COPY --from=build /usr/app/recover-id-object/target/release/recover-id-object ./
 
 RUN apt-get update && \
     apt-get -y install \
+    # curl is used to report errors to slack with
       ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Purpose

As part of the reporting in https://docs.google.com/document/d/1CxI5-c0bRdJm0C0THE18xh4DoTOLPRNn0Su2qWZMCrM we need to report an issue given a non successful recovery occurs. The output channel here is slack, and they use callbacks. Hence we need to use a callback which I would like to use curl for. 

## Changes

Install curl to dockerimage 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.