### PR TITLE
Individual rust versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,8 @@ on:
 
 env:
   RUST_FMT_VERSION: nightly-2023-04-01-x86_64-unknown-linux-gnu
-  RUST_VERSION: "1.74"
+  CRATE_TO_RUST_VERSION_MAP: '{"notification-server/Cargo.toml": "1.76"}'
+  DEFAULT_RUST_VERSION: "1.74"
 
 jobs:
 
@@ -98,7 +99,8 @@ jobs:
           submodules: recursive
       - name: Install Rust
         run: |
-          rustup default ${{ env.RUST_VERSION }}
+          RUST_VERSION=$(echo "${{ env.CRATE_TO_RUST_VERSION_MAP }}" | jq -r '.["${{ matrix.crates }}"] // "${{ env.DEFAULT_RUST_VERSION }}"')
+          rustup default $RUST_VERSION
           rustup component add clippy
       - name: Clippy
         run: |
@@ -119,7 +121,8 @@ jobs:
           submodules: recursive
       - name: Install Rust
         run: |
-          rustup default ${{ env.RUST_VERSION }}
+          RUST_VERSION=$(echo "${{ env.CRATE_TO_RUST_VERSION_MAP }}" | jq -r '.["${{ matrix.crates }}"] // "${{ env.DEFAULT_RUST_VERSION }}"')
+          rustup default $RUST_VERSION
       - name: Cargo tests
         run: |
           cargo test --manifest-path ${{ matrix.crates }} --locked

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
           submodules: recursive
       - name: Install Rust
         run: |
-          RUST_VERSION=$(echo "${{ env.CRATE_TO_RUST_VERSION_MAP }}" | jq -r '.["${{ matrix.crates }}"] // "${{ env.DEFAULT_RUST_VERSION }}"')
+          RUST_VERSION=$(echo '${{ env.CRATE_TO_RUST_VERSION_MAP }}' | jq -r '.["${{ matrix.crates }}"] // "${{ env.DEFAULT_RUST_VERSION }}"')
           rustup default $RUST_VERSION
           rustup component add clippy
       - name: Clippy
@@ -121,7 +121,7 @@ jobs:
           submodules: recursive
       - name: Install Rust
         run: |
-          RUST_VERSION=$(echo "${{ env.CRATE_TO_RUST_VERSION_MAP }}" | jq -r '.["${{ matrix.crates }}"] // "${{ env.DEFAULT_RUST_VERSION }}"')
+          RUST_VERSION=$(echo '${{ env.CRATE_TO_RUST_VERSION_MAP }}' | jq -r '.["${{ matrix.crates }}"] // "${{ env.DEFAULT_RUST_VERSION }}"')
           rustup default $RUST_VERSION
       - name: Cargo tests
         run: |

--- a/.github/workflows/release-notification-server.yml
+++ b/.github/workflows/release-notification-server.yml
@@ -10,7 +10,7 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: notification-server
-  RUST_VERSION: rust:1.74-buster  # Define the Rust version here
+  RUST_VERSION: rust:1.76-buster  # Define the Rust version here
 
 jobs:
   publish-docker-image:


### PR DESCRIPTION
## Purpose

I need a different rust version on the notification-server. I do not want to update all. Also logically it makes sense that we do not have to big bang bump all rust versions when we do that. 

## Changes

ci.yaml adding a map which takes different rust versions than default

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.