### PR TITLE
Change state compare to only output a diff

### DIFF
--- a/state-compare/CHANGELOG.md
+++ b/state-compare/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 - Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
-- Updated clap to version 4.
+- Reworked the tool so that it merely prints a diff without trying to determine if the differences are expected or not.
 
 ## 1.1.1
 

--- a/state-compare/CHANGELOG.md
+++ b/state-compare/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 - Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
+- Updated clap to version 4.
 
 ## 1.1.1
 

--- a/state-compare/Cargo.lock
+++ b/state-compare/Cargo.lock
@@ -76,6 +76,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,9 +707,12 @@ dependencies = [
  "concordium-rust-sdk",
  "futures",
  "indicatif",
+ "pretty_assertions",
  "serde_json",
  "tokio",
  "tonic",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -962,6 +974,12 @@ dependencies = [
  "rustc_version",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1506,6 +1524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1584,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1699,6 +1736,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1853,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1969,6 +2022,50 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rend"
@@ -2164,6 +2261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2292,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -2289,6 +2401,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -2516,6 +2638,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2563,6 +2715,12 @@ name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -2638,6 +2796,28 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2797,6 +2977,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/state-compare/Cargo.lock
+++ b/state-compare/Cargo.lock
@@ -97,6 +97,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,17 +306,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -512,42 +550,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -859,7 +904,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.58",
 ]
 
@@ -1210,18 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1396,6 +1432,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1604,7 +1646,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1655,12 +1697,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "password-hash"
@@ -1803,7 +1839,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -2179,6 +2214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,21 +2270,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -2527,6 +2553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,37 +2638,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/state-compare/Cargo.toml
+++ b/state-compare/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concordium-rust-sdk = { path = "../deps/concordium-rust-sdk", version = "*" }
 anyhow = "1"
-tokio = {version = "1.20", features = ["rt-multi-thread"]}
-futures = "0.3"
-clap = { version = "3", features = ["derive", "env"] }
 chrono = "0.4"
-tonic = "0.10"
-serde_json = "1.0"
+clap = { version = "4.5.11", features = ["derive", "env"] }
 colored = "2"
+concordium-rust-sdk = { path = "../deps/concordium-rust-sdk", version = "*" }
+futures = "0.3"
 indicatif = "0.17"
+serde_json = "1.0"
+tokio = {version = "1.20", features = ["rt-multi-thread"]}
+tonic = "0.10"

--- a/state-compare/Cargo.toml
+++ b/state-compare/Cargo.toml
@@ -13,6 +13,9 @@ colored = "2"
 concordium-rust-sdk = { path = "../deps/concordium-rust-sdk", version = "*" }
 futures = "0.3"
 indicatif = "0.17"
+pretty_assertions = "1.4.0"
 serde_json = "1.0"
 tokio = {version = "1.20", features = ["rt-multi-thread"]}
 tonic = "0.10"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/state-compare/README.md
+++ b/state-compare/README.md
@@ -1,6 +1,6 @@
 # State compare
 
-Check the state of two blocks. The main purpose of this tool is to check the
+Compares the state of two blocks. The main purpose of this tool is to inspect the
 state just before and after the protocol update, but in principle any two blocks
 can be supplied to print differences.
 
@@ -25,13 +25,10 @@ information.
 
 # State checks
 
-The following checks are performed.
+The following checks are performed and diffs are printed for any difference found:
 
 - The list of accounts in the two blocks are the same.
-- For each of the accounts in the list of accounts, the accounts are the same
-  modulo changes from P3 to P4. If `block1` is in P3 and `block2` is in P4 then
-  the equality check for accounts is relaxed and we allow that in `block2` an
-  account has baker pool information that it does not have in `block1`.
+- For each of the accounts in the list of accounts, the accounts are the same.
 - The list of smart contract modules is the same in both blocks, and the modules
   can be retrieved from both blocks, and their source code matches.
 - The list of smart contract instances is the same in both blocks, and for each
@@ -41,58 +38,19 @@ The following checks are performed.
   same, and the amounts are the same.
 - Active bakers agree. In particular the election difficulty is the same, and
   the bakers are the same, and have the same lottery power.
-- If both blocks are in protocols P4 and later then baker pools are checked. The
-  tool checks that the pools are the same, and have the same capital. It also
-  checks that the delegators for each pool are the same, which includes checking
-  that the staked amounts are the same, as well as any pending change.
+- Baker pools are checked. The tool checks that the pools are the same, and have
+  the same capital. It also checks that the delegators for each pool are the same,
+  which includes checking that the staked amounts are the same, as well as any
+  pending change.
 - Update sequence numbers are migrated correctly.
-- Election difficulty only checked for protocols before P6.
 
-## Example
-
-On mainnet running the tool when protocol version 4 is in effect leads to
-
-```
-$ concordium-state-compare --node1 http://localhost:20000
-Comparings state in blocks 5af81a1cc51141617f13c37e1cdea7ebdd76fce7e6377c0e7576b7450724472a (protocol version P3) and ea4a52a04ba905c2692b4598aa344707327781d588573d374125b449a1ce0bcc (protocol version P4).
-Comparing account lists.
-Querying all accounts.
-Comparing all modules.
-Querying all contracts.
-Checking passive delegators.
-Checking active bakers.
-Checking baker pools.
-Not comparing baker pools since one of the protocol versions is before P4.
-No changes in the state detected.
-```
-
-If two other blocks are chosen an example output shows what differs. For example
-on mainnet
-
-```
-$ concordium-state-compare --node1 http://localhost:20000 --block1 c58f6582361589dec16d07631081be5446e58b8e3c4f13b82b86d30f2f523706 --block2 abdebbfe582744e6e55ca43dfd4aa81f74d00e3e9010af5d9717203b26fddf39
-Comparings state in blocks c58f6582361589dec16d07631081be5446e58b8e3c4f13b82b86d30f2f523706 (protocol version P4) and abdebbfe582744e6e55ca43dfd4aa81f74d00e3e9010af5d9717203b26fddf39 (protocol version P4).
-Comparing account lists.
-Querying all accounts.
-Account 35CJPZohio6Ztii2zy1AYzJKvuxbGG44wrBn7hLHiYLoF2nxnh differs. It does not have stake either in c58f6582361589dec16d07631081be5446e58b8e3c4f13b82b86d30f2f523706 or abdebbfe582744e6e55ca43dfd4aa81f74d00e3e9010af5d9717203b26fddf39.
-Comparing all modules.
-Querying all contracts.
-Checking passive delegators.
-Checking active bakers.
-Checking baker pools.
-Pool 3 differs.
-Error: States in the two blocks c58f6582361589dec16d07631081be5446e58b8e3c4f13b82b86d30f2f523706 and abdebbfe582744e6e55ca43dfd4aa81f74d00e3e9010af5d9717203b26fddf39 differ.
-```
-
-The tool will exit with a non-zero status code if it fails to query some data,
-or there is a difference in state.
+The tool will exit with a non-zero status code if it fails to query some data.
 
 ## Caveats
 
 The state is checked using the node's API, so this is not a completely
-comprehensive check. However it provides a basic check that the state has been
-migrated correctly. The output is meant to indicate if there are issues, the
-tool does not print the exact difference between the states.
+comprehensive diff. The output is meant to be inspected manully to ensure
+that the changes make sense with regards to any protocol update.
 
 The tool at present requires a decent amount of memory since it loads the list
 of all accounts in memory, and also queries accounts and contract state in

--- a/state-compare/src/main.rs
+++ b/state-compare/src/main.rs
@@ -270,35 +270,17 @@ fn compare_iters<A: Display + PartialOrd>(
     while let Some(a1) = i1.peek() {
         if let Some(a2) = i2.peek() {
             if a1 < a2 {
-                warn!(
-                    "    {} {} appears in {} but not in {}.",
-                    msg,
-                    a1,
-                    block1,
-                    block2
-                );
+                warn!("    {msg} {a1} appears in {block1} but not in {block2}.",);
                 i1.next();
             } else if a2 < a1 {
-                warn!(
-                    "    {} {} appears in {} but not in {}.",
-                    msg,
-                    a2,
-                    block2,
-                    block1
-                );
+                warn!("    {msg} {a2} appears in {block2} but not in {block1}.",);
                 i2.next();
             } else {
                 i1.next();
                 i2.next();
             }
         } else {
-            warn!(
-                "    {} {} appears in {} but not in {}.",
-                msg,
-                a1,
-                block1,
-                block2
-            );
+            warn!("    {msg} {a1} appears in {block1} but not in {block2}.",);
             i1.next();
         }
     }
@@ -341,28 +323,13 @@ async fn compare_accounts(
         if a1.response != a2.response {
             match (&a1.response.account_stake, a2.response.account_stake) {
                 (None, None) => {
-                    warn!(
-                        "Account {} differs. It does not have stake either in {} or {}.",
-                        a1.response.account_address,
-                        block1,
-                        block2
-                    );
+                    warn!("Account {} differs. It does not have stake either in {block1} or {block2}.", a1.response.account_address);
                 }
                 (None, Some(_)) => {
-                    warn!(
-                        "Account {} differs. It does not have stake in {} but does in {}.",
-                        a1.response.account_address,
-                        block1,
-                        block2
-                    );
+                    warn!("Account {} differs. It does not have stake in {block1} but does in {block2}.", a1.response.account_address);
                 }
                 (Some(_), None) => {
-                    warn!(
-                        "Account {} differs. It does have stake in {} but does not in {}.",
-                        a1.response.account_address,
-                        block1,
-                        block2
-                    );
+                    warn!("Account {} differs. It does have stake in {block1} but does not in {block2}.", a1.response.account_address);
                 }
                 (Some(s1), Some(s2)) => {
                     // This is special case handling of P3->P4 upgrade.
@@ -392,39 +359,21 @@ async fn compare_accounts(
                                         ..a2.response
                                     };
                                     if a1.response != a2_no_pool {
-                                        warn!(
-                                            "Account {} differs. It does have stake in both {} \
-                                             and {}.",
-                                            a1.response.account_address,
-                                            block1,
-                                            block2
-                                        );
+                                        warn!("Account {} differs. It does have stake in both {block1} and {block2}.", a1.response.account_address);
                                     }
                                 }
                                 _ => {
-                                    warn!(
-                                        "Account {} differs. It does have stake in both {} and {}.",
-                                        a1.response.account_address,
-                                        block1,
-                                        block2
-                                    );
+                                    warn!("Account {} differs. It does have stake in both {block1} and {block2}.", a1.response.account_address);
                                 }
                             },
                             _ => {
-                                warn!(
-                                    "Account {} differs. It does have stake in both {} and {}.",
-                                    a1.response.account_address,
-                                    block1,
-                                    block2
-                                );
+                                warn!("Account {} differs. It does have stake in both {block1} and {block2}.", a1.response.account_address);
                             }
                         }
                     } else {
                         warn!(
-                            "Account {} differs. It does have stake in both {} and {}.",
-                            a1.response.account_address,
-                            block1,
-                            block2
+                            "Account {} differs. It does have stake in both {block1} and {block2}.",
+                            a1.response.account_address
                         );
                     }
                 }
@@ -454,7 +403,7 @@ async fn compare_modules(
             client2.get_module_source(&m, block2)
         )?;
         if m1.response != m2.response {
-            warn!("Module {} differs.", m);
+            warn!("Module {m} differs.");
         }
     }
 
@@ -481,7 +430,7 @@ async fn compare_instances(
             client2.get_instance_info(c, block2)
         )?;
         if ci1.response != ci2.response {
-            warn!("Instance {} differs.", c);
+            warn!("Instance {c} differs.");
         }
         let (mut state1, mut state2) = futures::try_join!(
             client1.get_instance_state(c, block1),
@@ -490,16 +439,16 @@ async fn compare_instances(
         while let Some(s1) = state1.response.next().await.transpose()? {
             if let Some(s2) = state2.response.next().await.transpose()? {
                 if s1 != s2 {
-                    warn!("State differs for {}.", c);
+                    warn!("State differs for {c}.");
                     break;
                 }
             } else {
-                warn!("State differs for {}.", c);
+                warn!("State differs for {c}.");
                 break;
             }
         }
         if state2.response.next().await.is_some() {
-            warn!("State differs for {}.", c);
+            warn!("State differs for {c}.");
         }
     }
 
@@ -611,7 +560,7 @@ async fn compare_baker_pools(
             ds1.sort_unstable_by_key(|x| x.account);
             ds2.sort_unstable_by_key(|x| x.account);
             if ds1 != ds2 {
-                warn!("Delegators for pool {} differ.", pool);
+                warn!("Delegators for pool {pool} differ.");
             }
 
             let (p1, p2) = futures::try_join!(
@@ -619,7 +568,7 @@ async fn compare_baker_pools(
                 client2.get_pool_info(block2, pool)
             )?;
             if p1.response != p2.response {
-                warn!("Pool {} differs.", pool);
+                warn!("Pool {pool} differs.");
             }
         }
     } else {

--- a/state-compare/src/main.rs
+++ b/state-compare/src/main.rs
@@ -118,6 +118,8 @@ async fn main() -> anyhow::Result<()> {
 
     compare_update_queues(&mut client1, &mut client2, block1, block2).await?;
 
+    info!("Done!");
+
     Ok(())
 }
 
@@ -149,6 +151,8 @@ async fn compare_update_queues(
     block1: BlockHash,
     block2: BlockHash,
 ) -> anyhow::Result<()> {
+    info!("Checking update queues.");
+
     let s1 = client1
         .get_next_update_sequence_numbers(block1)
         .await?

--- a/state-compare/src/main.rs
+++ b/state-compare/src/main.rs
@@ -405,8 +405,9 @@ async fn compare_passive_delegators(
     block2: BlockHash,
     pv1: ProtocolVersion,
     pv2: ProtocolVersion,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<()> {
     info!("Checking passive delegators.");
+
     let mut passive1 = if pv1 >= ProtocolVersion::P4 {
         client1
             .get_passive_delegators(block1)
@@ -417,6 +418,7 @@ async fn compare_passive_delegators(
     } else {
         Vec::new()
     };
+
     let mut passive2 = if pv2 >= ProtocolVersion::P4 {
         client2
             .get_passive_delegators(block2)
@@ -427,14 +429,13 @@ async fn compare_passive_delegators(
     } else {
         Vec::new()
     };
+
     passive1.sort_unstable_by_key(|x| x.account);
     passive2.sort_unstable_by_key(|x| x.account);
-    if passive1 != passive2 {
-        warn!("Passive delegators differ.");
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+
+    compare!(passive1, passive2, "Passive delegators");
+
+    Ok(())
 }
 
 async fn compare_active_bakers(

--- a/state-compare/src/main.rs
+++ b/state-compare/src/main.rs
@@ -22,7 +22,8 @@ use pretty_assertions::Comparison;
 use tracing::{info, level_filters::LevelFilter, warn};
 use tracing_subscriber::EnvFilter;
 
-/// Compares the given values and prints a pretty diff with the given message if they are not equal.
+/// Compares the given values and prints a pretty diff with the given message if
+/// they are not equal.
 macro_rules! compare {
     ($v1:expr, $v2:expr, $($arg:tt)*) => {
         if $v1 != $v2 {
@@ -50,7 +51,8 @@ struct Args {
 
     /// The first block to compare state against.
     ///
-    /// If not given the default is the last finalized block `before` the last protocol update.
+    /// If not given the default is the last finalized block `before` the last
+    /// protocol update.
     #[arg(long, env = "STATE_COMPARE_BLOCK1")]
     block1: Option<BlockHash>,
 
@@ -100,7 +102,10 @@ async fn main() -> anyhow::Result<()> {
 
     let (pv1, pv2) = get_protocol_versions(&mut client1, &mut client2, block1, block2).await?;
 
-    info!("Comparing states in blocks {block1} (protocol version {pv1}) and {block2} (protocol version {pv2}).");
+    info!(
+        "Comparing states in blocks {block1} (protocol version {pv1}) and {block2} (protocol \
+         version {pv2})."
+    );
 
     compare!(ci1.genesis_block, ci2.genesis_block, "Genesis blocks");
 
@@ -179,8 +184,9 @@ async fn compare_update_queues(
         .try_collect::<Vec<_>>()
         .await?;
 
-    // PendingUpdate unfortunately does not impl Eq so we'll settle for a comparison of their debug representations
-    // Should be good enough to produce a nice diff.
+    // PendingUpdate unfortunately does not impl Eq so we'll settle for a comparison
+    // of their debug representations Should be good enough to produce a nice
+    // diff.
     compare!(format!("{q1:#?}"), format!("{q2:#?}"), "Pending updates");
 
     Ok(())
@@ -494,8 +500,11 @@ async fn compare_baker_pools(
                 warn!("Failed to get delegators for pool {pool} in block 2: {e}");
                 continue;
             }
-            // The pool should definitely appear in the first block, we got the list of pools from that block.
-            (Err(e), Ok(_)) => return Err(e).with_context(|| format!("Failed to get delegators for pool {pool}")),
+            // The pool should definitely appear in the first block, we got the list of pools from
+            // that block.
+            (Err(e), Ok(_)) => {
+                return Err(e).with_context(|| format!("Failed to get delegators for pool {pool}"))
+            }
             (Err(e1), Err(e2)) => {
                 return Err(e2)
                     .context(e1)
@@ -522,7 +531,8 @@ async fn compare_baker_pools(
                 warn!("Failed to get pool {pool} in block 2: {e}");
                 continue;
             }
-            // The pool should definitely appear in the first block, we got the list of pools from that block.
+            // The pool should definitely appear in the first block, we got the list of pools from
+            // that block.
             (Err(e), Ok(_)) => return Err(e).with_context(|| format!("Failed to get pool {pool}")),
             (Err(e1), Err(e2)) => {
                 return Err(e2)


### PR DESCRIPTION
## Purpose

Previously this tool tried to take protocol versions into account and account for migration changes, to ensure that migrations are done correctly. However, doing this essentially involves re-implementing the migration changes every time a new protocol version is released. So we opt instead to merely print a diff of the changes between states. The user must then manually inspect the changes and decide for themselves whether they are expected or not.

## Changes

The tool has largely the same function structure as before but does not carry around a boolean any more to indicate if a difference was found. Differences are instead printed with color to indicate the changes.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
