### PR TITLE
Fix gcp format

### DIFF
--- a/notification-server/Cargo.lock
+++ b/notification-server/Cargo.lock
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "notification-server"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/notification-server/Cargo.toml
+++ b/notification-server/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Concordium AG developers@concordium.com"]
 edition = "2021"
 name = "notification-server"
-version = "0.1.11"
+version = "0.1.12"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/notification-server/src/google_cloud.rs
+++ b/notification-server/src/google_cloud.rs
@@ -144,6 +144,7 @@ where
             "token": device_token,
             "data": entity_data
         });
+        println!("Payload: {}", payload);
 
         let operation = || async {
             let response = self
@@ -397,8 +398,7 @@ mod tests {
                     "amount": "200",
                     "type": "cis2-tx",
                     "token_id": "ffffff",
-                    "contract_address_index": "3",
-                    "contract_address_subindex": "0",
+                    "contract_address": "{\"index\":3,\"subindex\":0}",
                     "contract_name": "init_contract",
                     "reference": "6a6d250ecefb518253db4c0d7759b2f4ff2862217ed2c8343879a77e0c2c97a2",
                 }
@@ -407,7 +407,7 @@ mod tests {
 
         let mock = server
             .mock("POST", "/v1/projects/fake_project_id/messages:send")
-            .match_body(mockito::Matcher::Json(expected_body))
+            .match_body(mockito::Matcher::Json(expected_body.clone()))
             .with_status(200)
             .with_body(json!({"success": true}).to_string())
             .expect(1)
@@ -441,6 +441,7 @@ mod tests {
                 )
                 .unwrap(),
             ));
+        println!("Expected: {}", expected_body);
         assert!(gc
             .send_push_notification("test_token", &notification_information)
             .await
@@ -463,11 +464,10 @@ mod tests {
                     "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
                     "amount": "200",
                     "type": "cis2-tx",
-                    "contract_address_index": "112",
-                    "contract_address_subindex": "2",
+                    "contract_address": "{\"index\":112,\"subindex\":2}",
                     "contract_name": "init_contract",
                     "token_id": "ffffff",
-                    "token_metadata_url": "https://example.com",
+                    "token_metadata": "{\"url\":\"https://example.com\",\"hash\":null}",
                     "reference": "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110",
                 }
             }
@@ -530,12 +530,10 @@ mod tests {
                     "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
                     "amount": "200",
                     "type": "cis2-tx",
-                    "contract_address_index": "111",
-                    "contract_address_subindex": "1",
+                    "contract_address": "{\"index\":111,\"subindex\":1}",
                     "contract_name": "init_contract",
                     "token_id": "ffffff",
-                    "token_metadata_hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-                    "token_metadata_url": "https://example.com",
+                    "token_metadata": "{\"url\":\"https://example.com\",\"hash\":\"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\"}",
                     "reference": "8a3a09bffa6ead269f79be4192fcb7773cc4e10a2e90c0dec3eb9ca5200c06bc"
                 }
             }

--- a/notification-server/src/google_cloud.rs
+++ b/notification-server/src/google_cloud.rs
@@ -144,7 +144,6 @@ where
             "token": device_token,
             "data": entity_data
         });
-        println!("Payload: {}", payload);
 
         let operation = || async {
             let response = self

--- a/notification-server/src/google_cloud.rs
+++ b/notification-server/src/google_cloud.rs
@@ -397,7 +397,8 @@ mod tests {
                     "amount": "200",
                     "type": "cis2-tx",
                     "token_id": "ffffff",
-                    "contract_address": {"index": 3, "subindex": 0},
+                    "contract_address_index": "3",
+                    "contract_address_subindex": "0",
                     "contract_name": "init_contract",
                     "reference": "6a6d250ecefb518253db4c0d7759b2f4ff2862217ed2c8343879a77e0c2c97a2",
                 }
@@ -462,10 +463,11 @@ mod tests {
                     "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
                     "amount": "200",
                     "type": "cis2-tx",
-                    "contract_address": {"index": 112, "subindex": 2},
+                    "contract_address_index": "112",
+                    "contract_address_subindex": "2",
                     "contract_name": "init_contract",
                     "token_id": "ffffff",
-                    "token_metadata": {"hash": None::<Hash>, "url": "https://example.com"},
+                    "token_metadata_url": "https://example.com",
                     "reference": "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110",
                 }
             }
@@ -528,10 +530,12 @@ mod tests {
                     "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
                     "amount": "200",
                     "type": "cis2-tx",
-                    "contract_address": {"index": 111, "subindex": 1},
+                    "contract_address_index": "111",
+                    "contract_address_subindex": "1",
                     "contract_name": "init_contract",
                     "token_id": "ffffff",
-                    "token_metadata": {"hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "url": "https://example.com"},
+                    "token_metadata_hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+                    "token_metadata_url": "https://example.com",
                     "reference": "8a3a09bffa6ead269f79be4192fcb7773cc4e10a2e90c0dec3eb9ca5200c06bc"
                 }
             }

--- a/notification-server/src/google_cloud.rs
+++ b/notification-server/src/google_cloud.rs
@@ -440,7 +440,6 @@ mod tests {
                 )
                 .unwrap(),
             ));
-        println!("Expected: {}", expected_body);
         assert!(gc
             .send_push_notification("test_token", &notification_information)
             .await

--- a/notification-server/src/models/notification.rs
+++ b/notification-server/src/models/notification.rs
@@ -86,19 +86,19 @@ impl CCDTransactionNotificationInformation {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CIS2EventNotificationInformation {
     #[serde(rename = "recipient")]
-    pub address:          AccountAddress,
-    pub amount:           String,
+    pub address:                   AccountAddress,
+    pub amount:                    String,
     #[serde(rename = "type")]
-    pub transaction_type: Preference,
-    pub token_id:         TokenId,
-    pub contract_address_index: String,
+    pub transaction_type:          Preference,
+    pub token_id:                  TokenId,
+    pub contract_address_index:    String,
     pub contract_address_subindex: String,
-    pub contract_name:    OwnedContractName,
+    pub contract_name:             OwnedContractName,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub token_metadata_url: Option<String>,
+    pub token_metadata_url:        Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub token_metadata_hash: Option<String>,
-    pub reference:        TransactionHash,
+    pub token_metadata_hash:       Option<String>,
+    pub reference:                 TransactionHash,
 }
 
 impl CIS2EventNotificationInformation {
@@ -120,7 +120,9 @@ impl CIS2EventNotificationInformation {
             contract_address_subindex: contract_address.subindex.to_string(),
             contract_name,
             token_metadata_url: token_metadata_url.clone().map(|url| url.url().to_string()),
-            token_metadata_hash: token_metadata_url.map(|url| url.hash().map(|hash| hash.to_string())).flatten(),
+            token_metadata_hash: token_metadata_url
+                .map(|url| url.hash().map(|hash| hash.to_string()))
+                .flatten(),
             reference,
         }
     }

--- a/notification-server/src/models/notification.rs
+++ b/notification-server/src/models/notification.rs
@@ -110,7 +110,6 @@ where
     serializer.serialize_str(&json_string)
 }
 
-// Function to serialize Option<T> using serde_json::to_string()
 fn serialize_option_as_json_string<S, T>(
     value: &Option<T>,
     serializer: S,

--- a/notification-server/src/models/notification.rs
+++ b/notification-server/src/models/notification.rs
@@ -91,10 +91,13 @@ pub struct CIS2EventNotificationInformation {
     #[serde(rename = "type")]
     pub transaction_type: Preference,
     pub token_id:         TokenId,
-    pub contract_address: ContractAddress,
+    pub contract_address_index: String,
+    pub contract_address_subindex: String,
     pub contract_name:    OwnedContractName,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub token_metadata:   Option<MetadataUrl>,
+    pub token_metadata_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_metadata_hash: Option<String>,
     pub reference:        TransactionHash,
 }
 
@@ -113,9 +116,11 @@ impl CIS2EventNotificationInformation {
             amount,
             transaction_type: Preference::CIS2Transaction,
             token_id,
-            contract_address,
+            contract_address_index: contract_address.index.to_string(),
+            contract_address_subindex: contract_address.subindex.to_string(),
             contract_name,
-            token_metadata: token_metadata_url,
+            token_metadata_url: token_metadata_url.clone().map(|url| url.url().to_string()),
+            token_metadata_hash: token_metadata_url.map(|url| url.hash().map(|hash| hash.to_string())).flatten(),
             reference,
         }
     }

--- a/notification-server/src/models/notification.rs
+++ b/notification-server/src/models/notification.rs
@@ -94,7 +94,10 @@ pub struct CIS2EventNotificationInformation {
     #[serde(serialize_with = "serialize_as_json_string")]
     pub contract_address: ContractAddress,
     pub contract_name:    OwnedContractName,
-    #[serde(serialize_with = "serialize_option_as_json_string", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "serialize_option_as_json_string",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub token_metadata:   Option<MetadataUrl>,
     pub reference:        TransactionHash,
 }
@@ -102,18 +105,19 @@ pub struct CIS2EventNotificationInformation {
 fn serialize_as_json_string<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
-    T: Serialize,
-{
+    T: Serialize, {
     let json_string = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
     serializer.serialize_str(&json_string)
 }
 
 // Function to serialize Option<T> using serde_json::to_string()
-fn serialize_option_as_json_string<S, T>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_option_as_json_string<S, T>(
+    value: &Option<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
-    T: Serialize,
-{
+    T: Serialize, {
     match value {
         Some(v) => serialize_as_json_string(v, serializer),
         None => serializer.serialize_none(),

--- a/notification-server/src/processor.rs
+++ b/notification-server/src/processor.rs
@@ -1,7 +1,3 @@
-use crate::models::notification::{
-    CCDTransactionNotificationInformation, CIS2EventNotificationInformationBasic,
-    NotificationInformationBasic,
-};
 use concordium_rust_sdk::{
     base::hashes::TransactionHash,
     cis2,
@@ -14,6 +10,11 @@ use concordium_rust_sdk::{
 };
 use futures::{Stream, StreamExt};
 use num_bigint::BigInt;
+
+use crate::models::notification::{
+    CCDTransactionNotificationInformation, CIS2EventNotificationInformationBasic,
+    NotificationInformationBasic,
+};
 
 fn convert<T: Into<BigInt>>(
     address: Address,
@@ -163,12 +164,8 @@ pub async fn process(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        models::notification::{
-            CCDTransactionNotificationInformation, NotificationInformationBasic,
-        },
-        processor::process,
-    };
+    use std::{fmt::Debug, str::FromStr};
+
     use concordium_rust_sdk::{
         base::{
             contracts_common::AccountAddress,
@@ -179,10 +176,10 @@ mod tests {
         constants::EncryptedAmountsCurve,
         encrypted_transfers::types::EncryptedAmount,
         types::{
-            hashes, hashes::TransactionHash, AccountCreationDetails, AccountTransactionDetails,
-            AccountTransactionEffects, BlockItemSummary, BlockItemSummaryDetails,
-            CredentialRegistrationID, CredentialType, EncryptedSelfAmountAddedEvent, Energy,
-            ExchangeRate, Memo, RejectReason, TransactionIndex, TransactionType, UpdateDetails,
+            AccountCreationDetails, AccountTransactionDetails, AccountTransactionEffects,
+            BlockItemSummary, BlockItemSummaryDetails, CredentialRegistrationID,
+            CredentialType, EncryptedSelfAmountAddedEvent, Energy, ExchangeRate,
+            hashes, Memo, RejectReason, TransactionIndex, TransactionType, UpdateDetails,
             UpdatePayload,
         },
     };
@@ -190,9 +187,15 @@ mod tests {
     use num_bigint::BigInt;
     use quickcheck::{Arbitrary, Gen};
     use quickcheck_macros::quickcheck;
-    use rand::{random, thread_rng, Rng};
+    use rand::{random, Rng, thread_rng};
     use sha2::Digest;
-    use std::{fmt::Debug, str::FromStr};
+
+    use crate::{
+        models::notification::{
+            CCDTransactionNotificationInformation, NotificationInformationBasic,
+        },
+        processor::process,
+    };
 
     #[derive(Clone, Debug)]
     struct ArbitraryTransactionIndex(pub TransactionIndex);

--- a/notification-server/src/processor.rs
+++ b/notification-server/src/processor.rs
@@ -164,8 +164,6 @@ pub async fn process(
 
 #[cfg(test)]
 mod tests {
-    use std::{fmt::Debug, str::FromStr};
-
     use concordium_rust_sdk::{
         base::{
             contracts_common::AccountAddress,
@@ -176,19 +174,19 @@ mod tests {
         constants::EncryptedAmountsCurve,
         encrypted_transfers::types::EncryptedAmount,
         types::{
-            AccountCreationDetails, AccountTransactionDetails, AccountTransactionEffects,
-            BlockItemSummary, BlockItemSummaryDetails, CredentialRegistrationID,
-            CredentialType, EncryptedSelfAmountAddedEvent, Energy, ExchangeRate,
-            hashes, Memo, RejectReason, TransactionIndex, TransactionType, UpdateDetails,
-            UpdatePayload,
+            hashes, AccountCreationDetails, AccountTransactionDetails, AccountTransactionEffects,
+            BlockItemSummary, BlockItemSummaryDetails, CredentialRegistrationID, CredentialType,
+            EncryptedSelfAmountAddedEvent, Energy, ExchangeRate, Memo, RejectReason,
+            TransactionIndex, TransactionType, UpdateDetails, UpdatePayload,
         },
     };
     use futures::stream;
     use num_bigint::BigInt;
     use quickcheck::{Arbitrary, Gen};
     use quickcheck_macros::quickcheck;
-    use rand::{random, Rng, thread_rng};
+    use rand::{random, thread_rng, Rng};
     use sha2::Digest;
+    use std::{fmt::Debug, str::FromStr};
 
     use crate::{
         models::notification::{

--- a/notification-server/src/processor.rs
+++ b/notification-server/src/processor.rs
@@ -1,3 +1,7 @@
+use crate::models::notification::{
+    CCDTransactionNotificationInformation, CIS2EventNotificationInformationBasic,
+    NotificationInformationBasic,
+};
 use concordium_rust_sdk::{
     base::hashes::TransactionHash,
     cis2,
@@ -10,11 +14,6 @@ use concordium_rust_sdk::{
 };
 use futures::{Stream, StreamExt};
 use num_bigint::BigInt;
-
-use crate::models::notification::{
-    CCDTransactionNotificationInformation, CIS2EventNotificationInformationBasic,
-    NotificationInformationBasic,
-};
 
 fn convert<T: Into<BigInt>>(
     address: Address,

--- a/notification-server/src/processor.rs
+++ b/notification-server/src/processor.rs
@@ -164,6 +164,12 @@ pub async fn process(
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        models::notification::{
+            CCDTransactionNotificationInformation, NotificationInformationBasic,
+        },
+        processor::process,
+    };
     use concordium_rust_sdk::{
         base::{
             contracts_common::AccountAddress,
@@ -187,13 +193,6 @@ mod tests {
     use rand::{random, thread_rng, Rng};
     use sha2::Digest;
     use std::{fmt::Debug, str::FromStr};
-
-    use crate::{
-        models::notification::{
-            CCDTransactionNotificationInformation, NotificationInformationBasic,
-        },
-        processor::process,
-    };
 
     #[derive(Clone, Debug)]
     struct ArbitraryTransactionIndex(pub TransactionIndex);


### PR DESCRIPTION
## Purpose

https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Message

Data only allows for String and String.

This means we need to take ownership of some of the types

## Changes

Changed serialisation for those fields which did not return a string

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.