### PR TITLE
Update all tool versions to support protocol 7

### DIFF
--- a/chain-prometheus-exporter/CHANGELOG.md
+++ b/chain-prometheus-exporter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased changes
+## 1.2.0
 - Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
 
 ## 1.1.2

--- a/chain-prometheus-exporter/Cargo.lock
+++ b/chain-prometheus-exporter/Cargo.lock
@@ -623,7 +623,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/chain-prometheus-exporter/Cargo.lock
+++ b/chain-prometheus-exporter/Cargo.lock
@@ -534,7 +534,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chain-prometheus-exporter"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/chain-prometheus-exporter/Cargo.toml
+++ b/chain-prometheus-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-prometheus-exporter"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chain-prometheus-exporter/src/main.rs
+++ b/chain-prometheus-exporter/src/main.rs
@@ -127,7 +127,7 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("Tracking account {address} with label {label}.");
         let opts = Opts::new(
             format!("{label}_balance"),
-            &format!("Balance of account {address} in microCCD."),
+            format!("Balance of account {address} in microCCD."),
         );
         let gauge: GenericGauge<AtomicU64> = GenericGauge::with_opts(opts)?;
         gauges.push((address, gauge.clone()));

--- a/generator/Cargo.lock
+++ b/generator/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/generator/src/generator.rs
+++ b/generator/src/generator.rs
@@ -740,13 +740,6 @@ struct RegisterCredentialsInitParams {
     revocation_keys: Vec<CredentialHolderId>,
 }
 
-#[derive(concordium_std::Serial)]
-struct RegisterCredentialParams {
-    credential_info: CredentialInfo,
-    #[concordium(size_length = 2)]
-    auxiliary_data:  Vec<u8>,
-}
-
 impl RegisterCredentialsGenerator {
     pub async fn instantiate(mut client: v2::Client, args: CommonArgs) -> anyhow::Result<Self> {
         // Get the initial nonce.

--- a/genesis-creator/CHANGELOG.md
+++ b/genesis-creator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased changes
+## 0.3.0
 
 - Support genesis data format of protocol version 7.
 - Updated the Concordium Rust SDK to support the changes introduced in protocol 7.

--- a/genesis-creator/Cargo.lock
+++ b/genesis-creator/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-creator"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/genesis-creator/Cargo.lock
+++ b/genesis-creator/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/genesis-creator/Cargo.toml
+++ b/genesis-creator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genesis-creator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/genesis-creator/src/lib.rs
+++ b/genesis-creator/src/lib.rs
@@ -93,8 +93,7 @@ fn crypto_parameters(
 /// Function for creating the genesis identity providers. The arguments are
 /// - idp_out - where to write the identity providers
 /// - cfgs - A vector of configurations, each deciding whether to use an
-///   existing identity provider or
-/// to generate one or more freshly.
+///   existing identity provider or to generate one or more freshly.
 ///
 /// For each generated anonymity revoker, the private identity provider data
 /// will be written to a file. The function returns a in a `anyhow::Result`,
@@ -177,8 +176,7 @@ fn identity_providers(
 /// Function for creating the genesis anonymity revokers. The arguments are
 /// - ars_out - where to write the anonymity revokers
 /// - cfgs - A vector of configurations, each deciding whether to use an
-///   existing anonymity revoker or
-/// to generate one or more freshly.
+///   existing anonymity revoker or to generate one or more freshly.
 ///
 /// For each generated anonymity revoker, the private anonymity revoker data
 /// will be written to a file. The function returns a in a `anyhow::Result`,

--- a/id-verifier/CHANGELOG.md
+++ b/id-verifier/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.4.0
+- Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
+
+## 0.3.0
+*Prior versions not kept in changelog.*

--- a/id-verifier/Cargo.lock
+++ b/id-verifier/Cargo.lock
@@ -604,7 +604,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/id-verifier/Cargo.lock
+++ b/id-verifier/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "id-verifier"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/id-verifier/Cargo.toml
+++ b/id-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id-verifier"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2021"
 license-file = "../../LICENSE-APACHE"
@@ -23,5 +23,3 @@ rand = "0.8"
 
 [dependencies.concordium-rust-sdk]
 path = "../deps/concordium-rust-sdk/"
-
-

--- a/kpi-tracker/CHANGELOG.md
+++ b/kpi-tracker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for the kpi-tracker service
 
-## Unreleased changes
+## 2.1.0
 - Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
 
 ## 2.0.0

--- a/kpi-tracker/Cargo.lock
+++ b/kpi-tracker/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-kpi-tracker"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/kpi-tracker/Cargo.lock
+++ b/kpi-tracker/Cargo.lock
@@ -604,7 +604,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/kpi-tracker/Cargo.toml
+++ b/kpi-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-kpi-tracker"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/notification-server/CHANGELOG.md
+++ b/notification-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.3.0
+- Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
+
+## 0.2.5
+*Prior versions not kept in changelog.*

--- a/notification-server/Cargo.lock
+++ b/notification-server/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64 0.21.7",
  "bs58",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/notification-server/Cargo.lock
+++ b/notification-server/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "notification-server"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/notification-server/Cargo.toml
+++ b/notification-server/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Concordium AG developers@concordium.com"]
 edition = "2021"
 name = "notification-server"
-version = "0.2.6"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/notification-server/src/database.rs
+++ b/notification-server/src/database.rs
@@ -242,7 +242,7 @@ mod tests {
         let bitmask = preferences_to_bitmask(preferences.clone().into_iter());
 
         let decoded_preferences = bitmask_to_preferences(bitmask);
-        let expected_preferences_set = HashSet::from_iter(preferences.into_iter());
+        let expected_preferences_set = HashSet::from_iter(preferences);
         let decoded_preferences_set = decoded_preferences;
 
         assert_eq!(decoded_preferences_set, expected_preferences_set);
@@ -455,15 +455,16 @@ mod tests {
             .prepared
             .insert_block(
                 &BlockHash::new(expected_hash),
-                &AbsoluteBlockHeight::from(AbsoluteBlockHeight::from(2)),
+                &AbsoluteBlockHeight::from(2),
             )
             .await
             .unwrap();
 
-        if let Err(_) = db_connection
+        if db_connection
             .prepared
             .insert_block(&BlockHash::new(expected_hash), &expected_height)
             .await
+            .is_err()
         {
             panic!("Expected ok result");
         }
@@ -479,10 +480,7 @@ mod tests {
 
         db_connection
             .prepared
-            .insert_block(
-                &BlockHash::new([0; 32]),
-                &AbsoluteBlockHeight::from(expected_height),
-            )
+            .insert_block(&BlockHash::new([0; 32]), &expected_height)
             .await
             .unwrap();
 

--- a/notification-server/src/google_cloud.rs
+++ b/notification-server/src/google_cloud.rs
@@ -218,8 +218,7 @@ mod tests {
     use std::{cmp::PartialEq, str::FromStr, sync::Arc, time::Duration};
 
     pub struct MockTokenProvider {
-        pub token_response: Arc<String>,
-        pub should_fail:    bool,
+        pub should_fail: bool,
     }
 
     fn generate_mock_token() -> Token {
@@ -334,10 +333,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_push_notification_ccd() {
         let mut server = mockito::Server::new_async().await;
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
 
         let expected_body = json!({
             "message": {
@@ -378,11 +374,7 @@ mod tests {
             ..ExponentialBackoff::default()
         };
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         let notification_information =
             NotificationInformation::CCD(CCDTransactionNotificationInformation::new(
                 AccountAddress::from_str("4FmiTW2L2AccyR9VjzsnpWFSAcohXWf7Vf797i36y526mqiEcp")
@@ -403,10 +395,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_push_notification_cis2_without_metadata_url() {
         let mut server = mockito::Server::new_async().await;
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
 
         let expected_body = json!({
             "message": {
@@ -450,11 +439,7 @@ mod tests {
             ..ExponentialBackoff::default()
         };
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         let notification_information =
             NotificationInformation::CIS2(CIS2EventNotificationInformation::new(
                 AccountAddress::from_str("3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G")
@@ -479,10 +464,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_push_notification_cis2_with_metadata_url() {
         let mut server = mockito::Server::new_async().await;
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
 
         let expected_body = json!({
             "message": {
@@ -526,11 +508,7 @@ mod tests {
             ..ExponentialBackoff::default()
         };
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         let notification_information =
             NotificationInformation::CIS2(CIS2EventNotificationInformation::new(
                 AccountAddress::from_str("3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G")
@@ -555,10 +533,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_push_notification_cis2_with_metadata_url_and_hash() {
         let mut server = mockito::Server::new_async().await;
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
 
         let expected_body = json!({
             "message": {
@@ -602,11 +577,7 @@ mod tests {
             ..ExponentialBackoff::default()
         };
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         let notification_information =
             NotificationInformation::CIS2(CIS2EventNotificationInformation::new(
                 AccountAddress::from_str("3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G")
@@ -642,10 +613,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_device_token_success() {
         let mut server = mockito::Server::new_async().await;
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
         let mock = server
             .mock("POST", "/v1/projects/fake_project_id/messages:send")
             .with_status(200)
@@ -657,11 +625,7 @@ mod tests {
         let client = Client::new();
         let backoff_policy = ExponentialBackoff::default();
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         assert!(gc.validate_device_token("valid_device_token").await.is_ok());
         mock.assert();
     }
@@ -669,10 +633,7 @@ mod tests {
     #[quickcheck]
     fn test_retry_on_retry_status_codes(status_code: RetryStatusCode) -> bool {
         let mut server = mockito::Server::new();
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
 
         let mock = server
             .mock("POST", "/v1/projects/fake_project_id/messages:send")
@@ -690,11 +651,7 @@ mod tests {
         };
 
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let result = runtime.block_on(gc.validate_device_token("valid_device_token"));
         mock.assert();
@@ -707,10 +664,7 @@ mod tests {
     #[quickcheck]
     fn test_retry_on_zero_retry_status_codes(status_code: ZeroRetryStatusCode) -> bool {
         let mut server = mockito::Server::new();
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
 
         let mock = server
             .mock("POST", "/v1/projects/fake_project_id/messages:send")
@@ -728,11 +682,7 @@ mod tests {
         };
 
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let result = runtime.block_on(gc.validate_device_token("valid_device_token"));
         mock.assert();
@@ -747,10 +697,7 @@ mod tests {
         server_side_status_code: RetryStatusCode,
     ) -> bool {
         let mut server = mockito::Server::new();
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    false,
-        };
+        let mock_provider = MockTokenProvider { should_fail: false };
 
         let failing_calls = server
             .mock("POST", "/v1/projects/fake_project_id/messages:send")
@@ -775,11 +722,7 @@ mod tests {
         };
 
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let result = runtime.block_on(gc.validate_device_token("valid_device_token"));
         failing_calls.assert();
@@ -790,10 +733,7 @@ mod tests {
     #[tokio::test]
     async fn should_not_continue_on_auth_failed() {
         let mut server = mockito::Server::new_async().await;
-        let mock_provider = MockTokenProvider {
-            token_response: Arc::new("mock_token".to_string()),
-            should_fail:    true,
-        };
+        let mock_provider = MockTokenProvider { should_fail: true };
         let mock = server
             .mock("POST", "/v1/projects/fake_project_id/messages:send")
             .with_status(200)
@@ -805,11 +745,7 @@ mod tests {
         let client = Client::new();
         let backoff_policy = ExponentialBackoff::default();
         let mut gc = GoogleCloud::new(client, backoff_policy, mock_provider, "mock_project_id");
-        gc.url = format!(
-            "{}{}",
-            server.url(),
-            "/v1/projects/fake_project_id/messages:send".to_string()
-        );
+        gc.url = format!("{}/v1/projects/fake_project_id/messages:send", server.url());
 
         mock.assert();
         let result = gc.validate_device_token("valid_device_token").await;

--- a/notification-server/src/processor.rs
+++ b/notification-server/src/processor.rs
@@ -194,17 +194,6 @@ mod tests {
     use std::{fmt::Debug, str::FromStr};
 
     #[derive(Clone, Debug)]
-    struct ArbitraryTransactionIndex(pub TransactionIndex);
-
-    // Implement Arbitrary for the wrapper
-    impl Arbitrary for ArbitraryTransactionIndex {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let index = u64::arbitrary(g);
-            ArbitraryTransactionIndex(TransactionIndex { index })
-        }
-    }
-
-    #[derive(Clone, Debug)]
     struct ArbitraryEnergy(pub Energy);
 
     impl Arbitrary for ArbitraryEnergy {
@@ -285,35 +274,27 @@ mod tests {
             let receiver_address = AccountAddress(random_account_address());
 
             let details = |effects| AccountTransactionDetails {
-                cost: amount.clone(),
+                cost: amount,
                 effects,
-                sender: receiver_address.clone(),
+                sender: receiver_address,
             };
             let effects = vec![
                 AccountTransactionEffects::AccountTransfer {
-                    amount: amount.clone(),
-                    to:     receiver_address.clone(),
+                    amount,
+                    to: receiver_address,
                 },
                 AccountTransactionEffects::AccountTransferWithMemo {
-                    amount: amount.clone(),
-                    to:     receiver_address.clone(),
-                    memo:   random_memo(),
+                    amount,
+                    to: receiver_address,
+                    memo: random_memo(),
                 },
                 AccountTransactionEffects::TransferredWithSchedule {
-                    to:     receiver_address.clone(),
-                    amount: create_random_release_schedules_from_amount(
-                        amount.clone().micro_ccd,
-                        2,
-                        g,
-                    ),
+                    to:     receiver_address,
+                    amount: create_random_release_schedules_from_amount(amount.micro_ccd, 2, g),
                 },
                 AccountTransactionEffects::TransferredWithScheduleAndMemo {
-                    to:     receiver_address.clone(),
-                    amount: create_random_release_schedules_from_amount(
-                        amount.clone().micro_ccd,
-                        2,
-                        g,
-                    ),
+                    to:     receiver_address,
+                    amount: create_random_release_schedules_from_amount(amount.micro_ccd, 2, g),
                     memo:   random_memo(),
                 },
             ];
@@ -321,10 +302,10 @@ mod tests {
             let effect = g.choose(&effects).unwrap().clone();
             let hash = fixed_hash();
             let summary = BlockItemSummary {
-                index:       random_transaction_index(),
+                index: random_transaction_index(),
                 energy_cost: ArbitraryEnergy::arbitrary(g).0,
-                hash:        hash.clone(),
-                details:     BlockItemSummaryDetails::AccountTransaction(details(effect.clone())),
+                hash,
+                details: BlockItemSummaryDetails::AccountTransaction(details(effect.clone())),
             };
 
             let notification =
@@ -356,9 +337,9 @@ mod tests {
             let receiver_address = AccountAddress(random_account_address());
 
             let account_transaction_details = |effects| AccountTransactionDetails {
-                cost: amount.clone(),
+                cost: amount,
                 effects,
-                sender: receiver_address.clone(),
+                sender: receiver_address,
             };
 
             let silent_block_summaries = vec![
@@ -398,8 +379,8 @@ mod tests {
                     hash: fixed_hash(),
                     details: BlockItemSummaryDetails::AccountTransaction(account_transaction_details(AccountTransactionEffects::TransferredToEncrypted {
                         data: Box::new(EncryptedSelfAmountAddedEvent {
-                            amount: amount.clone(),
-                            account: receiver_address.clone(),
+                            amount,
+                            account: receiver_address,
                             new_amount: EncryptedAmount {
                                 encryptions: [get_random_cipher(), get_random_cipher()],
                             },

--- a/recover-id-object/CHANGELOG.md
+++ b/recover-id-object/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased changes
+## 2.1.0
 - Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
 
 ## 2.0.1

--- a/recover-id-object/Cargo.lock
+++ b/recover-id-object/Cargo.lock
@@ -610,7 +610,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/recover-id-object/Cargo.lock
+++ b/recover-id-object/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "recover-id-object"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/recover-id-object/Cargo.toml
+++ b/recover-id-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recover-id-object"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -20,5 +20,3 @@ reqwest = { version = "0.11", features = ["json"] }
 url = { version = "2.3", features = ["serde"] }
 http = "0.2"
 chrono = "0.4.24"
-
-

--- a/state-compare/CHANGELOG.md
+++ b/state-compare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for the the state compare tool
 
-## Unreleased changes
+## 2.0.0
 - Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
 - Reworked the tool so that it merely prints a diff without trying to determine if the differences are expected or not.
 

--- a/state-compare/Cargo.lock
+++ b/state-compare/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "4.3.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/state-compare/Cargo.lock
+++ b/state-compare/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-state-compare"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/state-compare/Cargo.toml
+++ b/state-compare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-state-compare"
-version = "1.1.1"
+version = "2.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Purpose

Bumps all the tool versions to release the versions that support protocol 7.

## Changes

* Updated the Rust SDK to the 5.0.0 release.
* Got rid of various minor warnings.
* Bumped version of almost all the tools (I did not include the generator as that seems to have a protocol-7-supporting release already).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
