### PR TITLE
Fix pipeline fails

### DIFF
--- a/.github/workflows/release-notification-server.yml
+++ b/.github/workflows/release-notification-server.yml
@@ -10,7 +10,7 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: notification-server
-  RUST_VERSION: rust:1.76-buster  # Define the Rust version here
+  RUST_VERSION: rust:1.76-bookworm  # Define the Rust version here
 
 jobs:
   publish-docker-image:

--- a/notification-server/CHANGELOG.md
+++ b/notification-server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.7
+- Change type of image to be bookworm instead
+
 ## 0.3.6
 - Add a new endpoint to remove all accounts belonging to a device token
 

--- a/notification-server/Cargo.lock
+++ b/notification-server/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "notification-server"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/notification-server/Cargo.toml
+++ b/notification-server/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Concordium AG developers@concordium.com"]
 edition = "2021"
 name = "notification-server"
-version = "0.3.6"
+version = "0.3.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/notification-server/scripts/Dockerfile
+++ b/notification-server/scripts/Dockerfile
@@ -1,5 +1,5 @@
-ARG build_image=rust:1.76-buster
-ARG base_image=debian:buster-slim
+ARG build_image=rust:1.76-bookworm
+ARG base_image=debian:bookworm-slim
 FROM ${build_image} AS build
 
 WORKDIR /usr/app/notification-server


### PR DESCRIPTION
## Purpose

Pipeline release flow fails. 

As part of the installation I am doing:

http://apt.postgresql.org/pub/repos/apt/dists/

Which for some reason after the release during the weekend no longer contains a buster release. Since we are anyways using bookworm elsewhere this is the reason for such change