### PR TITLE
Genesis creator support for P8.

### DIFF
--- a/genesis-creator/CHANGELOG.md
+++ b/genesis-creator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Support genesis data format of protocol version 8.
+
 ## 0.3.0
 
 - Support genesis data format of protocol version 7.

--- a/genesis-creator/Cargo.lock
+++ b/genesis-creator/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-creator"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/genesis-creator/Cargo.toml
+++ b/genesis-creator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genesis-creator"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/genesis-creator/README.md
+++ b/genesis-creator/README.md
@@ -408,9 +408,9 @@ transactionFeeDistribution = { baker = 0.45, gasAccount = 0.45 }
 gASRewards = { baker = 0.25, finalizationProof = 0.005, accountCreation = 0.02, chainUpdate = 0.005 }
 ```
 
-#### Protocol version 6
+#### Protocol version 6 and 7
 
-Protocol version 6 parameters are provided in the following form:
+Protocol version 6 and 7 parameters are provided in the following form:
 
 ```toml
 [parameters]
@@ -461,6 +461,14 @@ gASRewards = { baker = 0.25, accountCreation = 0.02, chainUpdate = 0.005 }
 ```
 where the concrete values above are replaced with those desired.
 
+#### Protocol version 8
+
+Protocol version 8 parameters extend the version 6/7 parameters with one additional parameter:
+
+```toml
+[parameters.chain.validatorScoreParameters]
+maxMissedRounds = 10
+```
 
 ## The `assemble` mode
 To generate a genesis from existing file, run

--- a/genesis-creator/examples/genesis8.toml
+++ b/genesis-creator/examples/genesis8.toml
@@ -1,0 +1,124 @@
+# An example genesis configuration file to construct a protocol 6 genesis.
+# This creates a genesis with
+# - 5 bakers
+# - one additional foundation account
+# - genesis time set to the time when the tool runs
+# - minimum block time set to 1s
+
+protocolVersion = "8"
+
+[out]
+updateKeys = "./update-keys"
+accountKeys = "./accounts"
+bakerKeys = "./bakers"
+identityProviders = "./idps"
+anonymityRevokers = "./ars"
+genesis = "./genesis.dat"
+cryptographicParameters = "./global"
+deleteExisting = true
+genesisHash = "./genesis_hash"
+
+[cryptographicParameters]
+kind = "generate"
+genesisString = "Test genesis parameters."
+
+[[anonymityRevokers]]
+kind = "fresh"
+id = 1
+repeat = 3
+
+[[identityProviders]]
+kind = "fresh"
+id = 0
+repeat = 3
+
+[[accounts]]
+kind = "fresh"
+balance = "1000000000000000"
+stake = "500000000000000"
+template = "baker"
+identityProvider = 0
+numKeys = 1
+threshold = 1
+repeat = 5
+
+[[accounts]]
+kind = "fresh"
+balance = "1000000000000000"
+template = "foundation"
+identityProvider = 0
+numKeys = 1
+threshold = 1
+repeat = 1
+foundation = true
+
+[updates]
+root = { threshold = 5, keys = [{kind = "fresh", repeat = 7}]}
+level1 = { threshold = 7, keys = [{kind = "fresh", repeat = 15}]}
+
+[updates.level2]
+keys = [{kind = "fresh", repeat = 15}]
+emergency = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+protocol = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+electionDifficulty = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+euroPerEnergy = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+microCCDPerEuro = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+foundationAccount = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+mintDistribution = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+transactionFeeDistribution = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+gasRewards = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+poolParameters = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+addAnonymityRevoker = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+addIdentityProvider = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+cooldownParameters = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+timeParameters = {authorizedKeys = [0,1,2,3,4,5,6], threshold = 7}
+
+[parameters]
+# genesisTime = "2022-06-24T11:12:43Z" # Falls back to use the current time for genesis time.
+leadershipElectionNonce = "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1"
+epochDuration = "1h" # Meaning 1 hour.
+signatureThreshold = {numerator = 2, denominator = 3} # Must be between 2/3 and 1.
+
+[parameters.chain]
+minBlockTime = "1s" # Meaning 1 second.
+blockEnergyLimit = 3_000_000
+euroPerEnergy = 0.00002
+microCCDPerEuro = 500_000
+accountCreationLimit = 10
+
+[parameters.chain.timeoutParameters]
+base = "2s" # Meaning 2 seconds
+increase = 1.25 # Must be greater than 1.
+decrease = 0.8 # Must be between 0 and 1.
+
+[parameters.chain.finalizationCommitteeParameters]
+minFinalizers = 4
+maxFinalizers = 12
+finalizersRelativeStakeThreshold = 200 # parts per hundred thousand (n / 100000).
+
+[parameters.chain.timeParameters]
+rewardPeriodLength = 4 # 4 epochs
+mintPerPayday = 2.61157877e-4
+
+[parameters.chain.poolParameters]
+passiveFinalizationCommission = 1.0
+passiveBakingCommission = 0.12
+passiveTransactionCommission = 0.12
+finalizationCommissionRange = {max = 1.0, min = 1.0}
+bakingCommissionRange = {max = 0.1, min = 0.1}
+transactionCommissionRange = {max = 0.1, min = 0.1}
+minimumEquityCapital = "1000"
+capitalBound = 0.1
+leverageBound = {denominator = 1, numerator = 3}
+
+[parameters.chain.cooldownParameters]
+poolOwnerCooldown = 800 # in seconds
+delegatorCooldown = 1000 # in seconds
+
+[parameters.chain.rewardParameters]
+mintDistribution = { bakingReward = 0.85, finalizationReward = 0.05 }
+transactionFeeDistribution = { baker = 0.45, gasAccount = 0.45 }
+gASRewards = { baker = 0.25, accountCreation = 0.02, chainUpdate = 0.005 }
+
+[parameters.chain.validatorScoreParameters]
+maxMissedRounds = 10

--- a/genesis-creator/src/config.rs
+++ b/genesis-creator/src/config.rs
@@ -1,5 +1,5 @@
 //! Input configuration structures and parsing.
-use crate::genesis::{GenesisParametersConfigV0, GenesisParametersConfigV1};
+use crate::{genesis::{GenesisParametersConfigV0, GenesisParametersConfigV1}, GenesisParametersConfigV2};
 use anyhow::ensure;
 
 use concordium_rust_sdk::{
@@ -254,6 +254,10 @@ pub enum ProtocolConfig {
     P7 {
         parameters: GenesisParametersConfigV1,
     },
+    #[serde(rename = "8")]
+    P8 {
+        parameters: GenesisParametersConfigV2,
+    },
 }
 
 impl ProtocolConfig {
@@ -266,6 +270,7 @@ impl ProtocolConfig {
             ProtocolConfig::P5 { .. } => ProtocolVersion::P5,
             ProtocolConfig::P6 { .. } => ProtocolVersion::P6,
             ProtocolConfig::P7 { .. } => ProtocolVersion::P7,
+            ProtocolConfig::P8 { .. } => ProtocolVersion::P8,
         }
     }
 }


### PR DESCRIPTION
## Purpose

Support protocol version 8 in the `genesis-creator` tool.

## Changes

- Documentation
- Example configuration for P8
- `GenesisChainParametersV3` struct for constructing the `ChainParametersV3`.
- `GenesisParametersConfigV2` struct for the configuration used in P8.
- `GenesisStateCPV3` struct for the genesis state used in P8.
- Hashing an serialization of the genesis data.
- Bump `genesis-creator` version.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
