### PR TITLE
Update readme and implement simple test device for notifications

### DIFF
--- a/notification-server/README.md
+++ b/notification-server/README.md
@@ -11,21 +11,75 @@ API to obtain information about particular account to device mappings and store 
 Service indexing the CCD chain and given incoming transactions, emit a notification to the device
 associated with the account that received the transaction.
 
-## Setting up local dev
+This project uses Firebase Cloud Messaging (FCM) API V1 for the cross platform push notifications and is split into two binaries:
 
-```shell
-make setup && make
+- `service` traversing finalized blocks on chain sending notifications to devices registered in the database.
+- `api` providing a REST API for (de)registering devices in the database.
+
+## Setting up for development
+
+To be able to run the entire service locally, you first have to:
+
+- Create a firebase project with a service account and then [create and export keys](https://firebase.google.com/docs/cloud-messaging/auth-server?authuser=0#provide-credentials-manually) for this account.
+- Run PostgreSQL 16 server.
+
+### Migrate the database schema
+
+Database schema migrations are located in the `resources` directory and are prefixed incrementally.
+
+Example of how to run a migration using `psql`:
+
+```
+psql <db-connection> < resources/000-schema.sql
 ```
 
-where `make setup` will be a onetime setup and `make` will be continuously used to ensure containers are valid.
+### Configuring
 
-and run the application with 
+The service is configured using environment variables and supports reading `.env` file from the current working directory.
+
+An example of a `.env` which can be used as a template:
+
+```
+# Connection string for the postgresql database, used by both the service and the api.
+NOTIFICATION_SERVER_DB_CONNECTION="host=localhost dbname=notification_server user=postgres password=example port=5432"
+# Address and port to use for the API service.
+NOTIFICATION_SERVER_LISTEN_ADDRESS="0.0.0.0:3030"
+# Path to the Firebase SDK admin key export
+NOTIFICATION_SERVER_GOOGLE_APPLICATION_CREDENTIALS_PATH=./secrets/google-credentials.json
+# gRPC endpoint for the node, used by the service to observe the chain.
+NOTIFICATION_SERVER_BACKEND_NODE=https://grpc.testnet.concordium.com:20000
+```
+
+to build and run the application during development use:
 
 ```shell
 cargo run --bin <BINARY_NAME>
 ```
 
 where `<BINARY_NAME>` is the name of the binary you want to run.
+
+### Setup test FCM device and token
+
+Assuming you have a FCM test project ready, you can export a configuration and use the small test web application in `test-device`. It simulates a device and allows for generating a FCM token and interacting with the API to (un)subscribe to notifications.
+
+To export the firebase project config:
+
+Get Your Firebase Config:
+
+#. Go to your Firebase Console for your test project.
+#. Navigate to Project settings (the gear icon next to "Project Overview").
+#. Under the General tab, scroll down to the "Your apps" section.
+#. Click on your Web app. If you don't have one, click "Add app" and choose the web icon.
+#. Select the "Config" option for the Firebase SDK snippet.
+#. Copy the `apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, and `appId`.
+#. Crucially, also go to the "Cloud Messaging" tab in Project Settings. Under "Web configuration," find the "Key pair" section and copy the VAPID key.
+
+Then paste the config into the placeholders in both files in `test-device` directory.
+Paste the VAPID key into the `test-device/index.html`.
+
+Serve the directory on some port on localhost. Note that it is crucial this is on localhost for service-workers to work in modern browsers.
+
+Open the site and generate a token, this application should now receive notifications.
 
 ## API subscribe documentation
 

--- a/notification-server/test-device/firebase-messaging-sw.js
+++ b/notification-server/test-device/firebase-messaging-sw.js
@@ -1,0 +1,35 @@
+// firebase-messaging-sw.js
+// Give the service worker access to Firebase Messaging.
+// Replace 10.12.2 with the version of the Firebase JS SDK you're using in your app.
+importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js');
+
+// Initialize the Firebase app in the service worker by passing in
+// your app's Firebase config object.
+// IMPORTANT: Replace with YOUR actual project config from Firebase console
+// Go to Project settings > Your apps > Select your web app > Config
+const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+    projectId: "YOUR_PROJECT_ID",
+    storageBucket: "YOUR_PROJECT_ID.appspot.com",
+    messagingSenderId: "YOUR_MESSAGING_SENDER_ID", // CRUCIAL for FCM
+    appId: "YOUR_APP_ID"
+};
+firebase.initializeApp(firebaseConfig);
+
+// Retrieve an instance of Firebase Messaging so that it can handle
+// background messages.
+const messaging = firebase.messaging();
+
+// Add logic to handle background messages (e.g., display a notification)
+messaging.onBackgroundMessage((payload) => {
+  console.log('[firebase-messaging-sw.js] Received background message ', payload);
+  // Customize notification here
+  const notificationTitle = payload.notification.title;
+  const notificationOptions = {
+    body: payload.notification.body,
+    icon: '/firebase-logo.png' // Replace with your own icon URL
+  };
+  self.registration.showNotification(notificationTitle, notificationOptions);
+});

--- a/notification-server/test-device/index.html
+++ b/notification-server/test-device/index.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>FCM Testing device</title>
+        <style>
+         body {
+             font-family: Arial, sans-serif;
+             display: flex;
+             flex-direction: column;
+             align-items: center;
+             justify-content: center;
+             min-height: 100vh;
+             margin: 0;
+             background-color: #f0f2f5;
+             color: #333;
+         }
+         .container {
+             background-color: #fff;
+             padding: 30px;
+             border-radius: 8px;
+             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+             text-align: center;
+             max-width: 1200px;
+         }
+         h1 {
+             color: #4285F4; /* Firebase blue */
+             margin-bottom: 20px;
+         }
+         p {
+             margin-bottom: 15px;
+             line-height: 1.6;
+         }
+         button {
+             background-color: #FBBC04; /* Firebase orange */
+             color: white;
+             border: none;
+             padding: 12px 25px;
+             border-radius: 5px;
+             font-size: 16px;
+             cursor: pointer;
+             transition: background-color 0.3s ease;
+             margin-top: 20px;
+         }
+         button:hover {
+             background-color: #E6A000;
+         }
+         #tokenDisplay {
+             margin-top: 25px;
+             padding: 15px;
+             background-color: #e6e6e6;
+             border-radius: 5px;
+             word-break: break-all; /* Ensures long tokens wrap */
+             font-family: 'Courier New', Courier, monospace;
+             font-size: 14px;
+             text-align: left;
+         }
+         .error-message {
+             color: #d9534f; /* Bootstrap danger red */
+             margin-top: 15px;
+         }
+
+         .flex {
+             display: flex;
+         }
+         .flex-col {
+             flex-direction: column;
+         }
+         .flex-row {
+             flex-direction: row;
+         }
+        </style>
+        <!-- Firebase SDKs -->
+        <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+        <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js"></script>
+    </head>
+    <body>
+        <div class="container flex flex-col">
+            <div class="flex flex-row">
+                <div>
+                    <h1>Device Token</h1>
+                    <p>Click the button below to request notification permission and <br> generate your Firebase Cloud Messaging (FCM) device token.</p>
+                    <p>This token is unique to *this* browser and *this* app instance.</p>
+                    <button id="getTokenButton">Get your FCM Token</button>
+                    <div id="tokenDisplay">
+                        <strong>Your FCM Token will appear here:</strong> <br>
+                        <span id="fcmToken"></span>
+                    </div>
+                    <div id="errorMessage" class="error-message"></div>
+                </div>
+
+                <div>
+                    <h1>API Client</h1>
+                    <p>Subscribe or unsubscribe from receiving notifications</p>
+                    <label for="apiAddress">Address of the notification service API</label><br>
+                    <input id="apiAddress" value="http://localhost:3030" /><br>
+                    <label for="accountAddress">Address of the account(s) to link with the token<br>Multiple can be listed separated by a newline</label><br>
+                    <textarea id="accountAddress" value="" cols="54"> </textarea> <br>
+                    <input id="ccdTx" checked type="checkbox" /><label for="ccdTx">CCD events</label><br>
+                    <input id="cis2Tx" checked type="checkbox" /><label for="cis2Tx">CIS-2 events</label><br>
+                    <br>
+                    <button id="subscribeButton">Subscribe device</button>
+                    <button id="unsubscribeButton">Unsubscribe device</button>
+                    <div id="apiErrorMessage" class="error-message"></div>
+                    <div id="apiStatus"></div>
+                </div>
+            </div>
+            <div class="flex flex-col">
+                <h1>Notifications</h1>
+                <p>Device notifications will be shown below</p>
+                <div id="notifications" class="flex flex-col">
+                </div>
+            </div>
+        </div>
+
+        <script>
+         // Your Firebase project configuration
+         // IMPORTANT: Replace with YOUR actual project config from Firebase console
+         // Go to Project settings > Your apps > Select your web app > Config
+         const firebaseConfig = {
+             apiKey: "YOUR_API_KEY",
+             authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+             projectId: "YOUR_PROJECT_ID",
+             storageBucket: "YOUR_PROJECT_ID.appspot.com",
+             messagingSenderId: "YOUR_MESSAGING_SENDER_ID", // CRUCIAL for FCM
+             appId: "YOUR_APP_ID"
+         };
+         // --- VAPID Key ---
+         // Get this from Firebase Console: Project settings > Cloud Messaging > Web configuration
+         // You'll see a "Key pair" section. Copy the entire key string.
+         const VAPID_KEY = "YOUR_VAPID_KEY";
+
+         // Initialize Firebase
+         const app = firebase.initializeApp(firebaseConfig);
+         const messaging = firebase.messaging();
+
+         const fcmTokenSpan = document.getElementById('fcmToken');
+         // Get your FCM Token button behavior
+         document.getElementById('getTokenButton').addEventListener('click', async () => {
+             const errorMessageDiv = document.getElementById('errorMessage');
+             fcmTokenSpan.textContent = "Generating...";
+             errorMessageDiv.textContent = "";
+
+             try {
+                 // Request permission and get the token
+                 const currentToken = await messaging.getToken({ vapidKey: VAPID_KEY });
+                 if (currentToken) {
+                     fcmTokenSpan.textContent = currentToken;
+                 } else {
+                     fcmTokenSpan.textContent = "No token received. User might have denied permission.";
+                     errorMessageDiv.textContent = "Notification permission denied or blocked. Please enable notifications for this site in your browser settings.";
+                 }
+             } catch (err) {
+                 fcmTokenSpan.textContent = "Error generating token.";
+                 let displayError = "An error occurred: " + err.message;
+                 if (err.code === 'messaging/permission-blocked') {
+                     displayError = "Notifications are blocked for this site. Please unblock them in your browser settings.";
+                 } else if (err.code === 'messaging/failed-service-worker-registration') {
+                     displayError = "Service Worker registration failed. Ensure your server is set up correctly (e.g., using HTTPS in production).";
+                 }
+                 errorMessageDiv.textContent = displayError;
+             }
+         });
+
+         // Subscribe device button behavior
+         document.getElementById('subscribeButton').addEventListener('click', async () => {
+             const errorMessageDiv = document.getElementById('apiErrorMessage');
+             const token = fcmTokenSpan.textContent
+             if (token.length === 0 && token !== "Generating...") {
+                 errorMessageDiv.textContent = "First generate/get the FCM token";
+                 return;
+             }
+             // Get the API url
+             const apiAddress = document.getElementById('apiAddress');
+             const apiBaseUrl = apiAddress.value.trim();
+             // Get the accounts
+             const accountAddresesInput = document.getElementById('accountAddress');
+             const accounts = accountAddresesInput.value.split("\n").map((addr)=> addr.trim()).filter((n)=>n.length > 0);
+             // Get the preferences
+             let preferences = [];
+             if (document.getElementById('ccdTx').checked) {
+                 preferences.push("ccd-tx");
+             }
+             if (document.getElementById('cis2Tx').checked) {
+                 preferences.push("cis2-tx");
+             }
+             try {
+                 const body = {
+                     "device_token": token,
+                     preferences,
+                     accounts,
+                 };
+                 const url = `${apiBaseUrl}/api/v1/subscription`;
+                 console.log({url, body});
+                 const response = await fetch(url, {
+                     method: "PUT",
+                     headers: {
+                         "Content-Type": "application/json",
+                     },
+                     body: JSON.stringify(body)
+                 });
+                 if (!response.ok) {
+                     throw new Error(`Response status: ${response.status}`);
+                 }
+                 const text = await response.text();
+                 document.getElementById('apiStatus').textContent = text;
+                 errorMessageDiv.textContent = "";
+             } catch (err) {
+                 errorMessageDiv.textContent = "Failed request: " + err;
+             }
+         })
+
+         // Unsubscribe device button behavior
+         document.getElementById('unsubscribeButton').addEventListener('click', async () => {
+             const errorMessageDiv = document.getElementById('apiErrorMessage');
+             const token = fcmTokenSpan.textContent
+             if (token.length === 0 && token !== "Generating...") {
+                 errorMessageDiv.textContent = "First generate/get the FCM token";
+                 return;
+             }
+             // Get the API url
+             const apiAddress = document.getElementById('apiAddress');
+             const apiBaseUrl = apiAddress.value.trim();
+             try {
+                 const body = {
+                     "device_token": token
+                 };
+                 const url = `${apiBaseUrl}/api/v1/unsubscribe`;
+                 console.log({url, body});
+                 const response = await fetch(url, {
+                     method: "POST",
+                     headers: {
+                         "Content-Type": "application/json",
+                     },
+                     body: JSON.stringify(body)
+                 });
+                 if (!response.ok) {
+                     throw new Error(`Response status: ${response.status}`);
+                 }
+                 const text = await response.text();
+                 document.getElementById('apiStatus').textContent = text;
+                 errorMessageDiv.textContent = "";
+             } catch (err) {
+                 errorMessageDiv.textContent = "Failed request: " + err;
+             }
+         })
+
+         // Notification section
+         const notificationsContainer = document.getElementById('notifications');
+         messaging.onMessage((payload) => {
+             console.log('Message received. ', payload);
+             const p = document.createElement("p");
+             p.appendChild(document.createTextNode(JSON.stringify(payload)));
+             notificationsContainer.appendChild(p)
+         });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Purpose

Notification server readme is missing some details in how to get it up and running and provide no easy way to test the result.
This PR extends the readme and adds a small rough webapp to simulate the device to test notifications locally.

