### PR TITLE
Extend notifications for receiving PLT tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "notification-server"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/notification-server/CHANGELOG.md
+++ b/notification-server/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## 0.4.0
 - Extend notifications for receiving PLT tokens, when the relevant preference is set.
 
 ## 0.3.9

--- a/notification-server/CHANGELOG.md
+++ b/notification-server/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+- Extend notifications for receiving PLT tokens, when the relevant preference is set.
+
 ## 0.3.9
 - Dependency updates
 

--- a/notification-server/Cargo.toml
+++ b/notification-server/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Concordium AG developers@concordium.com"]
 edition = "2021"
 name = "notification-server"
-version = "0.3.10"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/notification-server/README.md
+++ b/notification-server/README.md
@@ -98,7 +98,7 @@ Should conflicts occur upon subscription updates, then only the preferences are 
 curl -X PUT "http://localhost:3030/api/v1/subscription" \
     -H "Content-Type: application/json" \
     -d '{
-        "preferences": ["cis2-tx", "ccd-tx"],
+        "preferences": ["cis2-tx", "ccd-tx", "plt-tx"],
         "accounts": ["4FmiTW2L2AccyR9VjzsnpWFSAcohXWf7Vf797i36y526mqiEcp"],
         "device_token": "<device_token>"
     }'

--- a/notification-server/src/google_cloud.rs
+++ b/notification-server/src/google_cloud.rs
@@ -590,7 +590,7 @@ mod tests {
                     "type": "plt-tx",
                     "token_id": "TestCoin",
                     "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
-                    "decimals": 6,
+                    "decimals": "6",
                     "value": "123456789",
                     "reference": "8a3a09bffa6ead269f79be4192fcb7773cc4e10a2e90c0dec3eb9ca5200c06bc",
                 }
@@ -619,7 +619,7 @@ mod tests {
                 address:   "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G"
                     .parse()
                     .unwrap(),
-                amount:    protocol_level_tokens::TokenAmount::from_raw(123456789, 6),
+                amount:    protocol_level_tokens::TokenAmount::from_raw(123456789, 6).into(),
                 token_id:  "TestCoin".parse().unwrap(),
                 reference: "8a3a09bffa6ead269f79be4192fcb7773cc4e10a2e90c0dec3eb9ca5200c06bc"
                     .parse()

--- a/notification-server/src/models/device.rs
+++ b/notification-server/src/models/device.rs
@@ -20,12 +20,13 @@ impl DeviceSubscription {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, Sequence)]
-#[serde(rename_all = "PascalCase")]
 pub enum Preference {
     #[serde(rename = "cis2-tx")]
     CIS2Transaction,
     #[serde(rename = "ccd-tx")]
     CCDTransaction,
+    #[serde(rename = "plt-tx")]
+    PLTTransaction,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]

--- a/notification-server/src/models/notification.rs
+++ b/notification-server/src/models/notification.rs
@@ -3,6 +3,7 @@ use concordium_rust_sdk::{
     base::{contracts_common::AccountAddress, smart_contracts::OwnedContractName},
     cis2::{Cis2QueryError, Cis2Type, MetadataUrl, TokenId},
     contract_client::ContractClient,
+    protocol_level_tokens,
     types::{hashes::TransactionHash, ContractAddress},
     v2::{Client, IntoBlockIdentifier},
 };
@@ -17,6 +18,7 @@ use std::ops::Deref;
 pub enum NotificationInformationBasic {
     CCD(CCDTransactionNotificationInformation),
     CIS2(CIS2EventNotificationInformationBasic),
+    PLT(PLTEventNotificationInformation),
 }
 
 /// Data transmitted in a notification.
@@ -29,6 +31,8 @@ pub enum NotificationInformation {
     CCD(CCDTransactionNotificationInformation),
     #[serde(rename = "cis2-tx")]
     CIS2(CIS2EventNotificationInformation),
+    #[serde(rename = "plt-tx")]
+    PLT(PLTEventNotificationInformation),
 }
 
 impl NotificationInformationBasic {
@@ -57,6 +61,7 @@ impl NotificationInformationBasic {
                     },
                 ))
             }
+            NotificationInformationBasic::PLT(info) => Ok(NotificationInformation::PLT(info)),
         }
     }
 }
@@ -127,6 +132,7 @@ impl NotificationInformationBasic {
         match self {
             NotificationInformationBasic::CCD(info) => &info.address,
             NotificationInformationBasic::CIS2(info) => &info.address,
+            NotificationInformationBasic::PLT(info) => &info.address,
         }
     }
 
@@ -135,6 +141,7 @@ impl NotificationInformationBasic {
         match self {
             NotificationInformationBasic::CCD(_) => Preference::CCDTransaction,
             NotificationInformationBasic::CIS2(_) => Preference::CIS2Transaction,
+            NotificationInformationBasic::PLT(_) => Preference::PLTTransaction,
         }
     }
 }
@@ -158,4 +165,18 @@ pub struct CIS2EventNotificationInformationBasic {
     pub contract_address: ContractAddress,
     /// Hash of the transaction which cause the notification.
     pub reference:        TransactionHash,
+}
+
+/// Notification information related to protocol-level tokens (PLT).
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PLTEventNotificationInformation {
+    /// Account address receiving some PLT token.
+    #[serde(rename = "recipient")]
+    pub address:   AccountAddress,
+    /// String encoding of the integer token amount.
+    pub amount:    protocol_level_tokens::TokenAmount,
+    /// The token identifier within the smart contract.
+    pub token_id:  protocol_level_tokens::TokenId,
+    /// Hash of the transaction which cause the notification.
+    pub reference: TransactionHash,
 }

--- a/notification-server/src/models/notification.rs
+++ b/notification-server/src/models/notification.rs
@@ -173,13 +173,34 @@ pub struct PLTEventNotificationInformation {
     /// Account address receiving some PLT token.
     #[serde(rename = "recipient")]
     pub address:   AccountAddress,
-    /// String encoding of the integer token amount.
+    /// The amount tokens received.
     #[serde(flatten)]
-    pub amount:    protocol_level_tokens::TokenAmount,
-    /// The token identifier within the smart contract.
+    pub amount:    PltAmount,
+    /// The identifier for the token being received.
     pub token_id:  protocol_level_tokens::TokenId,
     /// Hash of the transaction which cause the notification.
     pub reference: TransactionHash,
+}
+
+/// PLT token amount JSON serialization.
+///
+/// Since firebase notification data only supports key-values where values must
+/// be strings, we have to change the json serialization for the token amount.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PltAmount {
+    /// The amount of tokens as an unscaled integer value.
+    value:    String,
+    /// The number of decimals in the token amount.
+    decimals: String,
+}
+
+impl From<protocol_level_tokens::TokenAmount> for PltAmount {
+    fn from(amount: protocol_level_tokens::TokenAmount) -> Self {
+        Self {
+            value:    amount.value().to_string(),
+            decimals: amount.decimals().to_string(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -261,7 +282,7 @@ mod tests {
                     address:   "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G"
                         .parse()
                         .unwrap(),
-                    amount:    protocol_level_tokens::TokenAmount::from_raw(123456789, 6),
+                    amount:    protocol_level_tokens::TokenAmount::from_raw(123456789, 6).into(),
                     token_id:  "TestCoin".parse().unwrap(),
                     reference: "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110"
                         .parse()
@@ -272,7 +293,7 @@ mod tests {
                 "type": "plt-tx",
                 "token_id": "TestCoin",
                 "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
-                "decimals": 6,
+                "decimals": "6",
                 "value": "123456789",
                 "reference": "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110",
             });

--- a/notification-server/src/models/notification.rs
+++ b/notification-server/src/models/notification.rs
@@ -174,9 +174,112 @@ pub struct PLTEventNotificationInformation {
     #[serde(rename = "recipient")]
     pub address:   AccountAddress,
     /// String encoding of the integer token amount.
+    #[serde(flatten)]
     pub amount:    protocol_level_tokens::TokenAmount,
     /// The token identifier within the smart contract.
     pub token_id:  protocol_level_tokens::TokenId,
     /// Hash of the transaction which cause the notification.
     pub reference: TransactionHash,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    /// Test case to ensure changes to the JSON serialization are caught.
+    #[test]
+    fn test_serialize_notification_information() {
+        // CCD notification
+        {
+            let notification_information =
+                NotificationInformation::CCD(CCDTransactionNotificationInformation {
+                    address:   "4FmiTW2L2AccyR9VjzsnpWFSAcohXWf7Vf797i36y526mqiEcp"
+                        .parse()
+                        .unwrap(),
+                    amount:    "100".to_string(),
+                    reference: "3d1c2f4fb9a0eb468bfe39e75c59897c1a375082a6440f4a5da77102182ba055"
+                        .parse()
+                        .unwrap(),
+                });
+
+            let expected = json!({
+                "type": "ccd-tx",
+                "amount": "100",
+                "recipient": "4FmiTW2L2AccyR9VjzsnpWFSAcohXWf7Vf797i36y526mqiEcp",
+                "reference": "3d1c2f4fb9a0eb468bfe39e75c59897c1a375082a6440f4a5da77102182ba055"
+            });
+            assert_eq!(
+                expected,
+                serde_json::to_value(notification_information).unwrap()
+            )
+        }
+
+        // CIS-2 notification
+        {
+            let notification_information =
+                NotificationInformation::CIS2(CIS2EventNotificationInformation {
+                    contract_name:  OwnedContractName::new("init_contract".to_string()).unwrap(),
+                    token_metadata: Some(
+                        MetadataUrl::new("https://example.com".to_string(), None).unwrap(),
+                    ),
+                    info:           CIS2EventNotificationInformationBasic {
+                        address:          "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G"
+                            .parse()
+                            .unwrap(),
+                        amount:           "200".to_string(),
+                        token_id:         "ffffff".parse().unwrap(),
+                        contract_address: ContractAddress::new(112, 2),
+                        reference:
+                            "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110"
+                                .parse()
+                                .unwrap(),
+                    },
+                });
+
+            let expected = json!({
+                "type": "cis2-tx",
+                "amount": "200",
+                "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
+                "token_id": "ffffff",
+                "reference": "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110",
+                "token_metadata": "{\"url\":\"https://example.com\",\"hash\":null}",
+                "contract_address": "{\"index\":112,\"subindex\":2}",
+                "contract_name": "contract"
+            });
+            assert_eq!(
+                expected,
+                serde_json::to_value(notification_information).unwrap()
+            )
+        }
+
+        // PLT notification
+        {
+            let notification_information =
+                NotificationInformation::PLT(PLTEventNotificationInformation {
+                    address:   "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G"
+                        .parse()
+                        .unwrap(),
+                    amount:    protocol_level_tokens::TokenAmount::from_raw(123456789, 6),
+                    token_id:  "TestCoin".parse().unwrap(),
+                    reference: "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110"
+                        .parse()
+                        .unwrap(),
+                });
+
+            let expected = json!({
+                "type": "plt-tx",
+                "token_id": "TestCoin",
+                "recipient": "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
+                "decimals": 6,
+                "value": "123456789",
+                "reference": "494d7848e389d44a2c2fe81eeee6dc427ce33ab1d0c92cba23be321d495be110",
+            });
+            assert_eq!(
+                expected,
+                serde_json::to_value(notification_information).unwrap()
+            )
+        }
+    }
 }

--- a/notification-server/src/processor.rs
+++ b/notification-server/src/processor.rs
@@ -1,6 +1,6 @@
 use crate::models::notification::{
     CCDTransactionNotificationInformation, CIS2EventNotificationInformationBasic,
-    NotificationInformationBasic, PLTEventNotificationInformation,
+    NotificationInformationBasic, PLTEventNotificationInformation, PltAmount,
 };
 use concordium_rust_sdk::{
     base::hashes::TransactionHash,
@@ -125,7 +125,7 @@ fn map_transaction_to_notification_information(
                         let protocol_level_tokens::TokenHolder::Account { address } = to;
                         Some(PLTEventNotificationInformation {
                             address:   *address,
-                            amount:    *amount,
+                            amount:    PltAmount::from(*amount),
                             token_id:  token_event.token_id.clone(),
                             reference: transaction_hash,
                         })

--- a/notification-server/src/processor.rs
+++ b/notification-server/src/processor.rs
@@ -6,14 +6,13 @@ use concordium_rust_sdk::{
     base::hashes::TransactionHash,
     cis2::{self, Event},
     protocol_level_tokens,
-    types::{
-        self, AccountTransactionEffects, Address, BlockItemSummaryDetails::AccountTransaction,
-        ContractTraceElement,
-    },
+    types::{self, AccountTransactionEffects, Address, ContractTraceElement},
 };
 use futures::{Stream, StreamExt};
 use num_bigint::BigInt;
 
+/// Extract basic Notification Information from the effects of an account
+/// transaction.
 fn map_transaction_to_notification_information(
     effects: &AccountTransactionEffects,
     transaction_hash: TransactionHash,
@@ -108,34 +107,38 @@ fn map_transaction_to_notification_information(
                 },
             )]
         }
-        AccountTransactionEffects::TokenUpdate { events } => {
-            use concordium_rust_sdk::protocol_level_tokens::TokenEventDetails;
-            events
-                .iter()
-                .filter_map(|token_event| match &token_event.event {
-                    TokenEventDetails::Mint(protocol_level_tokens::TokenSupplyUpdateEvent {
-                        target: to,
-                        amount,
-                    })
-                    | TokenEventDetails::Transfer(protocol_level_tokens::TokenTransferEvent {
-                        to,
-                        amount,
-                        ..
-                    }) => {
-                        let protocol_level_tokens::TokenHolder::Account { address } = to;
-                        Some(PLTEventNotificationInformation {
-                            address:   *address,
-                            amount:    PltAmount::from(*amount),
-                            token_id:  token_event.token_id.clone(),
-                            reference: transaction_hash,
-                        })
-                    }
-                    TokenEventDetails::Burn(_) | TokenEventDetails::Module(_) => None,
-                })
-                .map(NotificationInformationBasic::PLT)
-                .collect()
-        }
+        AccountTransactionEffects::TokenUpdate { events } => events
+            .iter()
+            .filter_map(|token_event| map_plt_token_events(transaction_hash, token_event))
+            .map(NotificationInformationBasic::PLT)
+            .collect(),
         _ => vec![],
+    }
+}
+
+/// Extract Notification information from a single PLT event.
+fn map_plt_token_events(
+    transaction_hash: TransactionHash,
+    token_event: &protocol_level_tokens::TokenEvent,
+) -> Option<PLTEventNotificationInformation> {
+    use concordium_rust_sdk::protocol_level_tokens::TokenEventDetails;
+    match &token_event.event {
+        TokenEventDetails::Transfer(protocol_level_tokens::TokenTransferEvent {
+            to,
+            amount,
+            ..
+        }) => {
+            let protocol_level_tokens::TokenHolder::Account { address } = to;
+            Some(PLTEventNotificationInformation {
+                address:   *address,
+                amount:    PltAmount::from(*amount),
+                token_id:  token_event.token_id.clone(),
+                reference: transaction_hash,
+            })
+        }
+        TokenEventDetails::Mint(_) | TokenEventDetails::Burn(_) | TokenEventDetails::Module(_) => {
+            None
+        }
     }
 }
 
@@ -144,17 +147,25 @@ pub async fn process(
 ) -> Vec<NotificationInformationBasic> {
     transactions
         .filter_map(|result| async move { result.ok() })
-        .flat_map(|t| {
-            futures::stream::iter(match t.details {
-                AccountTransaction(ref account_transaction) => {
-                    map_transaction_to_notification_information(
-                        &account_transaction.effects,
-                        t.hash,
-                    )
-                }
-                _ => vec![],
-            })
-        })
+        .flat_map(
+            |t| -> futures::stream::Iter<std::vec::IntoIter<NotificationInformationBasic>> {
+                futures::stream::iter(match &t.details {
+                    types::BlockItemSummaryDetails::AccountTransaction(account_transaction) => {
+                        map_transaction_to_notification_information(
+                            &account_transaction.effects,
+                            t.hash,
+                        )
+                    }
+                    types::BlockItemSummaryDetails::TokenCreationDetails(details) => details
+                        .events
+                        .iter()
+                        .filter_map(|token_event| map_plt_token_events(t.hash, token_event))
+                        .map(NotificationInformationBasic::PLT)
+                        .collect(),
+                    _ => vec![],
+                })
+            },
+        )
         .collect::<Vec<NotificationInformationBasic>>()
         .await
 }

--- a/notification-server/test-device/index.html
+++ b/notification-server/test-device/index.html
@@ -99,7 +99,7 @@
                     <textarea id="accountAddress" value="" cols="54"> </textarea> <br>
                     <input id="ccdTx" checked type="checkbox" /><label for="ccdTx">CCD events</label><br>
                     <input id="cis2Tx" checked type="checkbox" /><label for="cis2Tx">CIS-2 events</label><br>
-                    <br>
+                    <input id="pltTx" checked type="checkbox" /><label for="pltTx">PLT events</label><br>
                     <button id="subscribeButton">Subscribe device</button>
                     <button id="unsubscribeButton">Unsubscribe device</button>
                     <div id="apiErrorMessage" class="error-message"></div>
@@ -184,6 +184,9 @@
              }
              if (document.getElementById('cis2Tx').checked) {
                  preferences.push("cis2-tx");
+             }
+             if (document.getElementById('pltTx').checked) {
+                 preferences.push("plt-tx");
              }
              try {
                  const body = {


### PR DESCRIPTION
## Purpose

Extend notifications for receiving PLT tokens, when the relevant preference is set.
[Task](https://linear.app/concordium/issue/COR-1697/update-notification-service-to-send-plt-notifications).

Builds on top of the minor refactor PR: https://github.com/Concordium/concordium-misc-tools/pull/252

## Changes

- Introduce a new preference "plt-tx"
- Introduce a new notification type.