### PR TITLE
Fix the P11 genesis hash calculation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-creator"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/genesis-creator/CHANGELOG.md
+++ b/genesis-creator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 0.8.2
+
+- Fix a bug in the computation of the genesis hash for protocol version 11.
+
 ## 0.8.0 and 0.8.1
 
 - Support genesis data format of protocol version 11.

--- a/genesis-creator/Cargo.toml
+++ b/genesis-creator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genesis-creator"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/genesis-creator/src/genesis.rs
+++ b/genesis-creator/src/genesis.rs
@@ -1003,6 +1003,7 @@ impl GenesisData {
                 core,
                 initial_state,
             } => {
+                ProtocolVersion::P11.serial(&mut hasher);
                 // tag of initial genesis
                 0u8.serial(&mut hasher);
                 core.serial(&mut hasher);


### PR DESCRIPTION
## Purpose

Fix a bug in the calculation of the P11 genesis hash in the genesis creator tool.

## Changes

- Include the P11 protocol version in the computation of the genesis hash.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
